### PR TITLE
Android Oreoのバグを踏まないように変更

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,8 +45,7 @@
             android:theme="@style/CustomizedSearchActivity"
             android:screenOrientation="landscape"/>
         <activity android:name=".SettingsActivity"
-            android:theme="@style/LeanbackPreferences"
-            android:screenOrientation="landscape"/>
+            android:theme="@style/LeanbackPreferences"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/daigorian/epcltvapp/SettingsActivity.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SettingsActivity.kt
@@ -2,12 +2,16 @@ package com.daigorian.epcltvapp
 
 
 import android.app.Activity
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+import android.os.Build
 import android.os.Bundle
 
 class SettingsActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_settings)
-
+        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
+            requestedOrientation = SCREEN_ORIENTATION_LANDSCAPE
+        }
     }
 }


### PR DESCRIPTION
はじめまして

この度我が家のAQUOSにて当アプリをインストールしてみたところ、アプリ起動後すぐにクラッシュしてしまいました。  
Logcatを見てみたところ、Android Oreo特有のバグもしくは問題？で```screenOrientation```にて横画面を指定できるのはフルスクリーンで実行されているアプリケーションのみつまり```isTranslucentOrFloating```がtrueだとだめ、という制約があります。そのため、我が家のAQUOSではクラッシュしていたようです。

参考：[Request: remove new restriction of Android 8.1 : "Only fullscreen activities can request orientation"](https://issuetracker.google.com/issues/68454482?pli=1)

そのため、マニフェストのSettingsActivityから```screenOrientation```を削除し、SettingsActivityの```onCreate```内にてOreo以外のバージョンのみ横固定にするよう変更しました。

我が家のAQUOSにてデバッグしてみましたが、縦画面になることなく使えておりますので大丈夫だと思われます。

あと気になる点ですが、マニフェストにて指定している```android:usesCleartextTraffic="true"```ですがこちらはAndroid SDK 23以上にて使える物だと認識しておりますが、このプロジェクトのmin SDK は22になっているためAndroid SDK 22のデバイスでは何かしらの影響がありそうです。
