### PR TITLE
libVLC 4.0 へアップデートし ARIB STD-B24 字幕に対応 (Leanback)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,5 +62,5 @@ dependencies {
     implementation "androidx.preference:preference-ktx:$preference_version"
 
     //libVLC
-    implementation 'org.videolan.android:libvlc-all:3.4.7'
+    implementation 'org.videolan.android:libvlc-all:4.0.0-eap24'
 }

--- a/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
@@ -13,6 +13,7 @@ import org.videolan.libvlc.LibVLC
 import org.videolan.libvlc.Media
 import org.videolan.libvlc.MediaPlayer
 import org.videolan.libvlc.MediaPlayer.*
+import org.videolan.libvlc.interfaces.IMedia
 import org.videolan.libvlc.util.VLCVideoLayout
 import java.io.IOException
 import java.util.*
@@ -42,6 +43,9 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
     var mBufferedProgress: Long = 0
 
 
+    // 字幕トラックのインデックス (-1 = OFF)
+    private var subtitleTrackIndex = -1
+
     var mDuration = -1L
     var mEstimatedDuration = -1L
     var mTime = -1L
@@ -64,6 +68,7 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
     fun reset() {
         Log.d(TAG, "reset()")
         changeToUninitialized()
+        subtitleTrackIndex = -1
         vlcPlayer.stop()
         if(vlcPlayer.hasMedia()){
             vlcPlayer.media?.release()
@@ -184,33 +189,24 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
 
     fun toggleClosedCaptioning(){
         Log.d(TAG, "toggleClosedCaptioning()")
-
-        if(vlcPlayer.spuTracks.isNullOrEmpty()) {
-            Toast.makeText(
-                mContext,
-                mContext.getString(R.string.no_subtitle),
-                Toast.LENGTH_SHORT
-            ).show()
-        }else{
-            val currentSubtitleTrackId = vlcPlayer.spuTrack
-
-            var currentSubtitleTrackIndex = -1
-            for (i in vlcPlayer.spuTracks.indices) {
-                if (vlcPlayer.spuTracks[i].id == currentSubtitleTrackId) {
-                    currentSubtitleTrackIndex = i
-                }
-            }
-
-            val nextSubtitleTrackIndex = (currentSubtitleTrackIndex + 1) % vlcPlayer.spuTracksCount
-
-            vlcPlayer.spuTrack = vlcPlayer.spuTracks[nextSubtitleTrackIndex].id
-            Toast.makeText(
-                mContext,
-                vlcPlayer.spuTracks[nextSubtitleTrackIndex].name,
-                Toast.LENGTH_SHORT
-            ).show()
+        val tracks = vlcPlayer.getTracks(IMedia.Track.Type.Text)
+        if (tracks.isNullOrEmpty()) {
+            Toast.makeText(mContext, mContext.getString(R.string.no_subtitle), Toast.LENGTH_SHORT).show()
+            return
         }
-
+        if (subtitleTrackIndex < 0) {
+            subtitleTrackIndex = 0
+            vlcPlayer.selectTrack(tracks[0].id)
+            Toast.makeText(mContext, tracks[0].name, Toast.LENGTH_SHORT).show()
+        } else if (subtitleTrackIndex >= tracks.size - 1) {
+            subtitleTrackIndex = -1
+            vlcPlayer.unselectTrackType(IMedia.Track.Type.Text)
+            Toast.makeText(mContext, mContext.getString(R.string.subtitle_off), Toast.LENGTH_SHORT).show()
+        } else {
+            subtitleTrackIndex++
+            vlcPlayer.selectTrack(tracks[subtitleTrackIndex].id)
+            Toast.makeText(mContext, tracks[subtitleTrackIndex].name, Toast.LENGTH_SHORT).show()
+        }
     }
 
     override fun seekTo(newPosition: Long) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="delete">Delete</string>
     <string name="cancel">Cancel</string>
     <string name="no_subtitle">No subtitle</string>
+    <string name="subtitle_off">Subtitle OFF</string>
     <string name="start_end_duration">%1$s - %2$s (%3$d min.)</string>
 
 


### PR DESCRIPTION
## 概要

Leanback UI 環境のまま libVLC を 3.4.7 → 4.0.0-eap24 へアップデートし、ARIB STD-B24 字幕に対応します。  
Compose 移行は含みません（`feature/compose-tv` 側の変更を Leanback 向けに移植したものです）。

## 変更内容

- `app/build.gradle`: `libvlc-all:3.4.7` → `libvlc-all:4.0.0-eap24`
- `VlcPlayerAdapter.kt`: `toggleClosedCaptioning()` を VLC 4.0 の新 API に書き換え
  - `spuTracks` → `getTracks(IMedia.Track.Type.Text)`
  - `spuTrack = id` → `selectTrack(id)` / `unselectTrackType(...)`
  - `subtitleTrackIndex` フィールドで状態管理（OFF → トラック1 → ... → OFF の循環）
  - `reset()` 時にインデックスをリセット
- `strings.xml`: `subtitle_off` 文字列を追加

## テスト計画

- [x] Android Studio で assembleDebug が BUILD SUCCESSFUL になること
- [x] エミュレーター or 実機で字幕なしコンテンツ再生時、字幕ボタンで "No subtitle" トーストが出ること
- [x] ARIB 字幕付き TS ファイル再生時、字幕ボタンで OFF → 字幕1 → OFF と循環すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)