### PR TITLE
feat: 録画済み0件の録画ルールを非表示にする設定を追加

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -736,6 +736,30 @@ class MainFragment : BrowseSupportFragment() {
             }//synchronized
         }
 
+        fun removeRowFromCategory(cat: Category, headerId: Long) {
+            synchronized(this) {
+                var rowIndex = -1
+                for (i in 0 until size()) {
+                    val row = get(i)
+                    if (row is ListRow && row.headerItem.id == headerId) {
+                        rowIndex = i
+                        break
+                    }
+                }
+                if (rowIndex == -1) return
+
+                super.removeItems(rowIndex, 1)
+                numOfRowInCategory[cat.ordinal]--
+
+                // DividerRow + SectionRow しか残っていない場合はそれも除去する
+                if (numOfRowInCategory[cat.ordinal] == 2) {
+                    val start = numOfRowInCategory.copyOfRange(0, cat.ordinal).sum()
+                    super.removeItems(start, 2)
+                    numOfRowInCategory[cat.ordinal] = 0
+                }
+            }
+        }
+
         fun updateContentsListRowWithCategory(v1Pram:GetRecordedParam,v2Param:GetRecordedParamV2,title:String,category:Category,idInCategory:Long){
 
             val headerId = category.ordinal.toLong()*10000 + idInCategory
@@ -812,6 +836,13 @@ class MainFragment : BrowseSupportFragment() {
                                 recording = v1Pram.recording))
                         }
 
+                        // 録画0件かつ設定がOFFの場合はルール行を非表示にする
+                        if (getRecordedResponse.total == 0L && category == Category.RECORDED_BY_RULES) {
+                            val showEmptyRules = PreferenceManager.getDefaultSharedPreferences(context)
+                                .getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+                            if (!showEmptyRules) removeRowFromCategory(category, headerId)
+                        }
+
                     }
                 }
                 override fun onFailure(call: Call<GetRecordedResponse>, t: Throwable) {
@@ -866,6 +897,14 @@ class MainFragment : BrowseSupportFragment() {
                                 keyword = v2Param.keyword,
                                 hasOriginalFile = v2Param.hasOriginalFile))
                         }
+
+                        // 録画0件かつ設定がOFFの場合はルール行を非表示にする
+                        if (getRecordedResponse.total == 0 && category == Category.RECORDED_BY_RULES) {
+                            val showEmptyRules = PreferenceManager.getDefaultSharedPreferences(context)
+                                .getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+                            if (!showEmptyRules) removeRowFromCategory(category, headerId)
+                        }
+
                     }
                 }
                 override fun onFailure(call: Call<Records>, t: Throwable) {

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -40,6 +40,7 @@
     <string name="program_name">番組名</string>
     <string name="set_newest_rule_first">録画ルールを新しい順に並べ替え</string>
     <string name="set_oldest_rule_first">録画ルールを古い順に並べ替え</string>
+    <string name="show_empty_rules">録画済み0件の録画ルールを表示する</string>
     <string name="use_custom_base_url">API Base URLを編集する</string>
     <string name="customize_base_url">API Base URL</string>
     <string name="do_you_want_to_delete">%1$s を削除しますか</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,9 @@
     <string name="set_newest_rule_first">Newest rule first</string>
     <string name="set_oldest_rule_first">Oldest rule first</string>
 
+    <string name="pref_key_show_empty_rules" translatable="false">KEY_SHOW_EMPTY_RULES</string>
+    <string name="show_empty_rules">Show recording rules with no recordings</string>
+
     <string name="pref_key_show_thumbnail_background" translatable="false">KEY_SHOW_THUMBNAIL_BACKGROUND</string>
     <string name="show_thumbnail_background">番組選択画面でサムネイルを背景表示する</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -41,6 +41,11 @@
         app:title="@string/show_thumbnail_background" />
 
     <SwitchPreference
+        app:key="@string/pref_key_show_empty_rules"
+        app:defaultValue="true"
+        app:title="@string/show_empty_rules" />
+
+    <SwitchPreference
         app:key="@string/pref_key_use_custom_base_url"
         app:defaultValue="false"
         app:title="@string/use_custom_base_url" />


### PR DESCRIPTION
## 概要

- 設定画面に「録画済み0件の録画ルールを表示する」スイッチを追加
- デフォルト ON（既存の動作を維持）
- OFF にすると、録画が1件もない録画ルール行をメイン画面から除去する

## 動作詳細

- 各ルールの録画一覧取得 API レスポンスで `total == 0` だった場合に行を削除
- 全ルールが0件になりセクションが空になった場合、セクションヘッダーと区切り線も合わせて除去
- EPGStation V1・V2 両方に対応

## テスト項目

- [x] 設定画面に「録画済み0件の録画ルールを表示する」スイッチが表示される
- [x] デフォルト ON の状態では録画0件のルール行も表示される（従来動作）
- [x] スイッチを OFF にしてリロードすると、録画0件のルール行が非表示になる
- [x] 録画がある録画ルールは OFF にしても表示され続ける
- [ ] 全録画ルールが0件の場合、「録画ルール」セクション自体が非表示になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)