### PR TITLE
feat: 設定画面をメイン画面のカード行に統合してリデザイン

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -12,7 +12,6 @@ import android.os.Handler
 import android.os.Looper
 import android.util.DisplayMetrics
 import android.util.Log
-import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
@@ -48,6 +47,9 @@ class MainFragment : BrowseSupportFragment() {
     private var mBackgroundUri: String? = null
     private var mNeedsReloadAllOnResume = false
     private var mNeedsReloadHistoryOnResume = false
+    private var mNeedsCheckConnectionOnResume = false
+    private var mConnectionKeyBeforeSettings: String? = null
+    private var mSettingsRowAdapter: ArrayObjectAdapter? = null
 
     private val mCardPresenter = OriginalCardPresenter()
     private val mMainMenuListRowPresenter = ListRowPresenter()
@@ -59,6 +61,9 @@ class MainFragment : BrowseSupportFragment() {
 
         adapter = mMainMenuAdapter
         mCardPresenter.objAdapter = mMainMenuAdapter
+
+        // プレイヤー設定などデフォルト値をSharedPreferencesに書き込む（初回のみ）
+        androidx.preference.PreferenceManager.setDefaultValues(requireContext(), R.xml.preferences, false)
 
         if(!SettingsFragment.isPreferenceAllExists(requireContext())){
             Log.i(TAG, "not all Preference exists")
@@ -87,18 +92,29 @@ class MainFragment : BrowseSupportFragment() {
     override fun onResume() {
         Log.i(TAG, "onResume")
         super.onResume()
-        if(mNeedsReloadAllOnResume && SettingsFragment.isPreferenceAllExists(requireContext())) {
-            //設定画面から戻ってきたのでEPGStationの接続からやり直す
-            initEPGStationApi()
-            mNeedsReloadAllOnResume = false
-        }else if(mNeedsReloadHistoryOnResume) {
-            //履歴行の読み直し
-            mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
-            updateRows()
-            mNeedsReloadHistoryOnResume = false
-        }else{
-            //コンテンツをアップデートする。
-            updateRows()
+        when {
+            mNeedsReloadAllOnResume && SettingsFragment.isPreferenceAllExists(requireContext()) -> {
+                // 初回起動など、接続設定が揃った後のフル初期化
+                initEPGStationApi()
+                mNeedsReloadAllOnResume = false
+            }
+            mNeedsCheckConnectionOnResume -> {
+                // 接続設定から戻ってきた場合、設定値が変わっていれば再接続
+                mNeedsCheckConnectionOnResume = false
+                if (connectionKey() != mConnectionKeyBeforeSettings) {
+                    initEPGStationApi()
+                }
+                // 変わっていなければ何もしない
+            }
+            mNeedsReloadHistoryOnResume -> {
+                // 履歴行の読み直し
+                mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
+                updateRows()
+                mNeedsReloadHistoryOnResume = false
+            }
+            else -> {
+                updateRows()
+            }
         }
 
     }
@@ -374,26 +390,76 @@ class MainFragment : BrowseSupportFragment() {
 
         //"設定"　のボタンが乗る行
         val gridHeader = HeaderItem(-Category.SETTINGS.ordinal.toLong(), getString(R.string.settings))
-        val gridPresenter = GridItemPresenter()
+        val gridPresenter = SettingsCardPresenter()
         val gridRowAdapter = ArrayObjectAdapter(gridPresenter)
-        gridRowAdapter.add(resources.getString(R.string.settings))
-        gridRowAdapter.add(resources.getString(R.string.reload))
+        mSettingsRowAdapter = gridRowAdapter
 
-        //ルールの並び順を表すフラグ。デフォルトfalse。
-        val isNewestFirst = PreferenceManager.getDefaultSharedPreferences(context).getBoolean(getString(R.string.pref_key_rules_order_is_newest_first),false)
-        if (isNewestFirst){
-            gridRowAdapter.add(resources.getString(R.string.set_oldest_rule_first))
-        }else{
-            gridRowAdapter.add(resources.getString(R.string.set_newest_rule_first))
-        }
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
 
+        gridRowAdapter.add(SettingsCardPresenter.Item(
+            R.drawable.ic_settings_connection,
+            getString(R.string.settings_connection),
+            SettingsCardPresenter.Item.Action.CONNECTION
+        ))
+        gridRowAdapter.add(SettingsCardPresenter.Item(
+            R.drawable.ic_settings_player,
+            getString(R.string.settings_player),
+            SettingsCardPresenter.Item.Action.PLAYER
+        ))
+        gridRowAdapter.add(SettingsCardPresenter.Item(
+            R.drawable.ic_settings_reload,
+            getString(R.string.reload),
+            SettingsCardPresenter.Item.Action.RELOAD
+        ))
 
-        mMainMenuAdapter.addToCategory(Category.SETTINGS,ListRow(gridHeader, gridRowAdapter))
+        // ラベル・アイコンはクリック後に得られる状態を表す
+        val isNewestFirst = prefs.getBoolean(getString(R.string.pref_key_rules_order_is_newest_first), false)
+        gridRowAdapter.add(SettingsCardPresenter.Item(
+            if (isNewestFirst) R.drawable.ic_settings_sort_asc else R.drawable.ic_settings_sort_desc,
+            if (isNewestFirst) getString(R.string.settings_card_sort_oldest) else getString(R.string.settings_card_sort_newest),
+            SettingsCardPresenter.Item.Action.RULES_ORDER
+        ))
+
+        val showBg = prefs.getBoolean(getString(R.string.pref_key_show_thumbnail_background), false)
+        gridRowAdapter.add(SettingsCardPresenter.Item(
+            R.drawable.ic_settings_image,
+            if (showBg) getString(R.string.settings_card_bg_off) else getString(R.string.settings_card_bg_on),
+            SettingsCardPresenter.Item.Action.BACKGROUND
+        ))
+
+        val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+        gridRowAdapter.add(SettingsCardPresenter.Item(
+            if (showEmptyRules) R.drawable.ic_settings_unfold_less else R.drawable.ic_settings_unfold_more,
+            if (showEmptyRules) getString(R.string.settings_card_rules_hide) else getString(R.string.settings_card_rules_show),
+            SettingsCardPresenter.Item.Action.EMPTY_RULES
+        ))
+
+        mMainMenuAdapter.addToCategory(Category.SETTINGS, ListRow(gridHeader, gridRowAdapter))
 
 
 
     }
 
+
+    /** 設定行を保持したまま、コンテンツ行だけをクリアして再読み込みする */
+    private fun reloadContentRows() {
+        listOf(Category.ON_RECORDING, Category.RECENTLY_RECORDED, Category.SEARCH_HISTORY, Category.RECORDED_BY_RULES)
+            .forEach { mMainMenuAdapter.deleteCategory(it) }
+        updateRows()
+    }
+
+    /** 接続設定の変化検知用フィンガープリント */
+    private fun connectionKey(): String {
+        val prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(requireContext())
+        val useCustomUrl = prefs.getBoolean(getString(R.string.pref_key_use_custom_base_url), false)
+        return if (useCustomUrl) {
+            prefs.getString(getString(R.string.pref_key_custom_base_url), "") ?: ""
+        } else {
+            val ip = prefs.getString(getString(R.string.pref_key_ip_addr), "") ?: ""
+            val port = prefs.getString(getString(R.string.pref_key_port_num), "") ?: ""
+            "$ip:$port"
+        }
+    }
 
     private fun setupEventListeners() {
         setOnSearchClickedListener {
@@ -445,33 +511,57 @@ class MainFragment : BrowseSupportFragment() {
                         .toBundle()
                     startActivity(intent, bundle)
                 }
-                is String -> {
-                    //設定、再読み込みなどのアイテム
-                    when {
-                        item.contains(getString(R.string.settings)) -> {
+                is SettingsCardPresenter.Item -> {
+                    val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+                    when (item.action) {
+                        SettingsCardPresenter.Item.Action.CONNECTION -> {
+                            mConnectionKeyBeforeSettings = connectionKey()
+                            mNeedsCheckConnectionOnResume = true
                             val intent = Intent(context!!, SettingsActivity::class.java)
+                            intent.putExtra(SettingsActivity.EXTRA_START_SCREEN, getString(R.string.pref_key_screen_connection))
                             startActivity(intent)
-                            mNeedsReloadAllOnResume = true
                         }
-                        item.contains(getString(R.string.reload)) -> {
-                            loadRows()
+                        SettingsCardPresenter.Item.Action.PLAYER -> {
+                            // 再生設定はコンテンツリストに影響しないので戻り時に再読み込みしない
+                            val intent = Intent(context!!, SettingsActivity::class.java)
+                            intent.putExtra(SettingsActivity.EXTRA_START_SCREEN, getString(R.string.pref_key_screen_player))
+                            startActivity(intent)
                         }
-                        item.contains(getString(R.string.set_newest_rule_first)) -> {
-                            PreferenceManager.getDefaultSharedPreferences(context)
-                                .edit()
-                                .putBoolean(getString(R.string.pref_key_rules_order_is_newest_first),true)
-                                .commit()
-                            loadRows()
+                        SettingsCardPresenter.Item.Action.RELOAD -> {
+                            reloadContentRows()
                         }
-                        item.contains(getString(R.string.set_oldest_rule_first)) -> {
-                            PreferenceManager.getDefaultSharedPreferences(context)
-                                .edit()
-                                .putBoolean(getString(R.string.pref_key_rules_order_is_newest_first),false)
-                                .commit()
-                            loadRows()
+                        SettingsCardPresenter.Item.Action.RULES_ORDER -> {
+                            val isNewestFirst = prefs.getBoolean(getString(R.string.pref_key_rules_order_is_newest_first), false)
+                            val newIsNewestFirst = !isNewestFirst
+                            prefs.edit().putBoolean(getString(R.string.pref_key_rules_order_is_newest_first), newIsNewestFirst).commit()
+                            mSettingsRowAdapter?.replace(SETTINGS_IDX_RULES_ORDER, SettingsCardPresenter.Item(
+                                if (newIsNewestFirst) R.drawable.ic_settings_sort_asc else R.drawable.ic_settings_sort_desc,
+                                if (newIsNewestFirst) getString(R.string.settings_card_sort_oldest) else getString(R.string.settings_card_sort_newest),
+                                SettingsCardPresenter.Item.Action.RULES_ORDER
+                            ))
+                            reloadContentRows()
                         }
-                        else -> {
-                            Toast.makeText(context!!, item, Toast.LENGTH_LONG).show()
+                        SettingsCardPresenter.Item.Action.BACKGROUND -> {
+                            val showBg = prefs.getBoolean(getString(R.string.pref_key_show_thumbnail_background), false)
+                            val newShowBg = !showBg
+                            prefs.edit().putBoolean(getString(R.string.pref_key_show_thumbnail_background), newShowBg).commit()
+                            startBackgroundTimer()
+                            mSettingsRowAdapter?.replace(SETTINGS_IDX_BACKGROUND, SettingsCardPresenter.Item(
+                                R.drawable.ic_settings_image,
+                                if (newShowBg) getString(R.string.settings_card_bg_off) else getString(R.string.settings_card_bg_on),
+                                SettingsCardPresenter.Item.Action.BACKGROUND
+                            ))
+                        }
+                        SettingsCardPresenter.Item.Action.EMPTY_RULES -> {
+                            val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+                            val newShowEmptyRules = !showEmptyRules
+                            prefs.edit().putBoolean(getString(R.string.pref_key_show_empty_rules), newShowEmptyRules).commit()
+                            mSettingsRowAdapter?.replace(SETTINGS_IDX_EMPTY_RULES, SettingsCardPresenter.Item(
+                                if (newShowEmptyRules) R.drawable.ic_settings_unfold_less else R.drawable.ic_settings_unfold_more,
+                                if (newShowEmptyRules) getString(R.string.settings_card_rules_hide) else getString(R.string.settings_card_rules_show),
+                                SettingsCardPresenter.Item.Action.EMPTY_RULES
+                            ))
+                            reloadContentRows()
                         }
                     }
                 }
@@ -639,25 +729,6 @@ class MainFragment : BrowseSupportFragment() {
         override fun run() {
             mHandler.post { updateBackground(mBackgroundUri) }
         }
-    }
-
-    private inner class GridItemPresenter : Presenter() {
-        override fun onCreateViewHolder(parent: ViewGroup): ViewHolder {
-            val view = TextView(parent.context)
-            view.layoutParams = ViewGroup.LayoutParams(GRID_ITEM_WIDTH, GRID_ITEM_HEIGHT)
-            view.isFocusable = true
-            view.isFocusableInTouchMode = true
-            view.setBackgroundColor(ContextCompat.getColor(context!!, R.color.default_background))
-            view.setTextColor(Color.WHITE)
-            view.gravity = Gravity.CENTER
-            return ViewHolder(view)
-        }
-
-        override fun onBindViewHolder(viewHolder: ViewHolder, item: Any) {
-            (viewHolder.view as TextView).text = item as String
-        }
-
-        override fun onUnbindViewHolder(viewHolder: ViewHolder) {}
     }
 
     enum class Category {
@@ -1016,8 +1087,11 @@ class MainFragment : BrowseSupportFragment() {
         private const val TAG = "MainFragment"
 
         private const val BACKGROUND_UPDATE_DELAY = 300
-        private const val GRID_ITEM_WIDTH = 200
-        private const val GRID_ITEM_HEIGHT = 200
+
+        // loadRows() で追加する設定カードの順序インデックス
+        private const val SETTINGS_IDX_RULES_ORDER = 3
+        private const val SETTINGS_IDX_BACKGROUND  = 4
+        private const val SETTINGS_IDX_EMPTY_RULES  = 5
     }
 
 

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -539,7 +539,7 @@ class MainFragment : BrowseSupportFragment() {
                                 if (newIsNewestFirst) getString(R.string.settings_card_sort_oldest) else getString(R.string.settings_card_sort_newest),
                                 SettingsCardPresenter.Item.Action.RULES_ORDER
                             ))
-                            reloadContentRows()
+                            mMainMenuAdapter.reverseRulesOrder()
                         }
                         SettingsCardPresenter.Item.Action.BACKGROUND -> {
                             val showBg = prefs.getBoolean(getString(R.string.pref_key_show_thumbnail_background), false)
@@ -561,7 +561,11 @@ class MainFragment : BrowseSupportFragment() {
                                 if (newShowEmptyRules) getString(R.string.settings_card_rules_hide) else getString(R.string.settings_card_rules_show),
                                 SettingsCardPresenter.Item.Action.EMPTY_RULES
                             ))
-                            reloadContentRows()
+                            if (newShowEmptyRules) {
+                                updateRows() // 行を追加するだけなので構造変化なし、フォーカス維持
+                            } else {
+                                mMainMenuAdapter.removeEmptyRuleRows() // 0件行だけを個別削除
+                            }
                         }
                     }
                 }
@@ -988,6 +992,38 @@ class MainFragment : BrowseSupportFragment() {
 
 
 
+
+        /** ルール行の並び順を物理的に逆転する（行の削除/追加なし → フォーカス維持） */
+        fun reverseRulesOrder() {
+            synchronized(this) {
+                val catOrdinal = Category.RECORDED_BY_RULES.ordinal
+                val totalInCat = numOfRowInCategory[catOrdinal]
+                val headerRows = 2 // DividerRow + SectionRow
+                val count = totalInCat - headerRows
+                if (count <= 1) return
+                val start = numOfRowInCategory.copyOfRange(0, catOrdinal).sum() + headerRows
+                for (i in 0 until count - 1) {
+                    move(start + count - 1, start + i)
+                }
+            }
+        }
+
+        /** 録画0件のルール行だけをピンポイントで削除する（他の行を削除しない → フォーカス維持） */
+        fun removeEmptyRuleRows() {
+            val catOrdinal = Category.RECORDED_BY_RULES.ordinal
+            val totalInCat = numOfRowInCategory[catOrdinal]
+            if (totalInCat == 0) return
+            val headerRows = 2 // DividerRow + SectionRow
+            val catStart = numOfRowInCategory.copyOfRange(0, catOrdinal).sum()
+            val emptyIds = mutableListOf<Long>()
+            for (i in catStart + headerRows until catStart + totalInCat) {
+                val row = get(i) as? ListRow ?: continue
+                if ((row.adapter as? ArrayObjectAdapter)?.size() == 0) {
+                    emptyIds.add(row.headerItem.id)
+                }
+            }
+            emptyIds.forEach { removeRowFromCategory(Category.RECORDED_BY_RULES, it) }
+        }
 
         fun sortRulesByRecordedDate(){
             synchronized(this){

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -539,7 +539,8 @@ class MainFragment : BrowseSupportFragment() {
                                 if (newIsNewestFirst) getString(R.string.settings_card_sort_oldest) else getString(R.string.settings_card_sort_newest),
                                 SettingsCardPresenter.Item.Action.RULES_ORDER
                             ))
-                            mMainMenuAdapter.reverseRulesOrder()
+                            mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
+                            updateRows()
                         }
                         SettingsCardPresenter.Item.Action.BACKGROUND -> {
                             val showBg = prefs.getBoolean(getString(R.string.pref_key_show_thumbnail_background), false)
@@ -992,21 +993,6 @@ class MainFragment : BrowseSupportFragment() {
 
 
 
-
-        /** ルール行の並び順を物理的に逆転する（行の削除/追加なし → フォーカス維持） */
-        fun reverseRulesOrder() {
-            synchronized(this) {
-                val catOrdinal = Category.RECORDED_BY_RULES.ordinal
-                val totalInCat = numOfRowInCategory[catOrdinal]
-                val headerRows = 2 // DividerRow + SectionRow
-                val count = totalInCat - headerRows
-                if (count <= 1) return
-                val start = numOfRowInCategory.copyOfRange(0, catOrdinal).sum() + headerRows
-                for (i in 0 until count - 1) {
-                    move(start + count - 1, start + i)
-                }
-            }
-        }
 
         /** 録画0件のルール行だけをピンポイントで削除する（他の行を削除しない → フォーカス維持） */
         fun removeEmptyRuleRows() {

--- a/app/src/main/java/com/daigorian/epcltvapp/SettingsActivity.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SettingsActivity.kt
@@ -1,17 +1,35 @@
 package com.daigorian.epcltvapp
 
-
 import android.app.Activity
 import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
 import android.os.Build
 import android.os.Bundle
 
 class SettingsActivity : Activity() {
+
+    companion object {
+        const val EXTRA_START_SCREEN = "start_screen"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_settings)
         if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
             requestedOrientation = SCREEN_ORIENTATION_LANDSCAPE
+        }
+
+        if (savedInstanceState == null) {
+            val fragment = SettingsFragment()
+            val startScreen = intent.getStringExtra(EXTRA_START_SCREEN)
+            if (startScreen != null) {
+                fragment.arguments = Bundle().apply {
+                    putString(SettingsFragment.ARG_START_SCREEN, startScreen)
+                }
+            }
+            @Suppress("DEPRECATION")
+            fragmentManager.beginTransaction()
+                .replace(R.id.settings_container, fragment)
+                .commit()
         }
     }
 }

--- a/app/src/main/java/com/daigorian/epcltvapp/SettingsCardPresenter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SettingsCardPresenter.kt
@@ -1,0 +1,49 @@
+package com.daigorian.epcltvapp
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import androidx.leanback.widget.Presenter
+
+class SettingsCardPresenter : Presenter() {
+
+    data class Item(
+        @DrawableRes val iconRes: Int,
+        val label: String,
+        val action: Action
+    ) {
+        enum class Action {
+            CONNECTION, PLAYER, RELOAD, RULES_ORDER, BACKGROUND, EMPTY_RULES
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_settings_card, parent, false)
+        view.layoutParams = ViewGroup.LayoutParams(CARD_SIZE, CARD_SIZE)
+        view.isFocusable = true
+        view.isFocusableInTouchMode = true
+        view.setOnFocusChangeListener { v, hasFocus ->
+            v.setBackgroundColor(
+                if (hasFocus) ContextCompat.getColor(parent.context, R.color.selected_background)
+                else ContextCompat.getColor(parent.context, R.color.default_background)
+            )
+        }
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(viewHolder: ViewHolder, item: Any) {
+        val card = item as Item
+        viewHolder.view.findViewById<ImageView>(R.id.settings_card_icon).setImageResource(card.iconRes)
+        viewHolder.view.findViewById<TextView>(R.id.settings_card_text).text = card.label
+    }
+
+    override fun onUnbindViewHolder(viewHolder: ViewHolder) {}
+
+    companion object {
+        private const val CARD_SIZE = 200
+    }
+}

--- a/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
@@ -10,9 +10,37 @@ import androidx.preference.DialogPreference.TargetFragment
 
 
 class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
+
+    companion object {
+        const val ARG_START_SCREEN = "start_screen"
+        private const val PREFERENCE_RESOURCE_ID = "preferenceResource"
+        private const val PREFERENCE_ROOT = "root"
+
+        private const val IP_REGEX_PATTERN = """^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"""
+        private const val PORT_REGEX_PATTERN = """^([1-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"""
+
+        fun isPreferenceAllExists(context: Context): Boolean {
+            val pref = PreferenceManager.getDefaultSharedPreferences(context)
+            val useCustomUrl = pref.getBoolean(context.getString(R.string.pref_key_use_custom_base_url), false)
+            return if (useCustomUrl) {
+                !pref.getString(context.getString(R.string.pref_key_custom_base_url), "").isNullOrEmpty()
+            } else {
+                val ipRegEx = Regex(pattern = IP_REGEX_PATTERN)
+                val ipString = pref.getString(context.getString(R.string.pref_key_ip_addr), "")
+                if (ipString?.matches(ipRegEx) != true) return false
+
+                val portRegEx = Regex(pattern = PORT_REGEX_PATTERN)
+                val portString = pref.getString(context.getString(R.string.pref_key_port_num), "")
+                portString?.matches(portRegEx) == true
+            }
+        }
+    }
+
     private var mPreferenceFragment: PreferenceFragment? = null
+
     override fun onPreferenceStartInitialScreen() {
-        mPreferenceFragment = buildPreferenceFragment(R.xml.preferences, null)
+        val startScreen = arguments?.getString(ARG_START_SCREEN)
+        mPreferenceFragment = buildPreferenceFragment(R.xml.preferences, startScreen)
         startPreferenceFragment(mPreferenceFragment!!)
     }
 
@@ -27,27 +55,16 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
         preferenceFragment: PreferenceFragment,
         preferenceScreen: PreferenceScreen
     ): Boolean {
-        val frag = buildPreferenceFragment(
-            R.xml.preferences,
-            preferenceScreen.key
-        )
+        val frag = buildPreferenceFragment(R.xml.preferences, preferenceScreen.key)
         startPreferenceFragment(frag)
         return true
     }
 
-
     private fun buildPreferenceFragment(preferenceResId: Int, root: String?): PreferenceFragment {
-        val fragment: PreferenceFragment =
-            PrefFragment()
+        val fragment: PreferenceFragment = PrefFragment()
         val args = Bundle()
-        args.putInt(
-            PREFERENCE_RESOURCE_ID,
-            preferenceResId
-        )
-        args.putString(
-            PREFERENCE_ROOT,
-            root
-        )
+        args.putInt(PREFERENCE_RESOURCE_ID, preferenceResId)
+        args.putString(PREFERENCE_ROOT, root)
         fragment.arguments = args
         return fragment
     }
@@ -56,7 +73,7 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
         return mPreferenceFragment!!.findPreference(key)
     }
 
-    class PrefFragment : LeanbackPreferenceFragment()  {
+    class PrefFragment : LeanbackPreferenceFragment() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             val root = arguments.getString(PREFERENCE_ROOT, null)
             val prefResId = arguments.getInt(PREFERENCE_RESOURCE_ID)
@@ -66,47 +83,37 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
                 setPreferencesFromResource(prefResId, root)
             }
 
-
-            //IPアドレスの入力時バリデーション
             val ipAddressPref = preferenceScreen.findPreference(getText(R.string.pref_key_ip_addr)) as EditTextPreference?
             ipAddressPref?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, value ->
-                val regex = Regex(pattern =IP_REGEX_PATTERN)
-                if (value.toString().matches(regex)){
+                val regex = Regex(pattern = IP_REGEX_PATTERN)
+                if (value.toString().matches(regex)) {
                     true
-                }else{
-                    Toast.makeText(activity, getString(R.string.not_a_valid_ipv4_addr,value.toString()), Toast.LENGTH_LONG).show()
+                } else {
+                    Toast.makeText(activity, getString(R.string.not_a_valid_ipv4_addr, value.toString()), Toast.LENGTH_LONG).show()
                     false
                 }
-
             }
 
-            //PORT番号の入力時バリデーション
             val portNumPref = preferenceScreen.findPreference(getText(R.string.pref_key_port_num)) as EditTextPreference?
             portNumPref?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, value ->
-                val regex = Regex(pattern =PORT_REGEX_PATTERN)
-                if (value.toString().matches(regex)){
+                val regex = Regex(pattern = PORT_REGEX_PATTERN)
+                if (value.toString().matches(regex)) {
                     true
-                }else{
-                    Toast.makeText(activity, getString(R.string.not_a_valid_port_num,value.toString()), Toast.LENGTH_LONG).show()
+                } else {
+                    Toast.makeText(activity, getString(R.string.not_a_valid_port_num, value.toString()), Toast.LENGTH_LONG).show()
                     false
                 }
             }
 
-            // カスタムベースURLを使うかどうかでUIをだし分け。
-            val useCustomBaseUrlPref =  preferenceScreen.findPreference(getText(R.string.pref_key_use_custom_base_url)) as SwitchPreference?
-            //初回ロード時
-            useCustomBaseUrlPref?.let{
-                enableCustomBaseUrlUI(it.isChecked)
-            }
-            //編集時
+            val useCustomBaseUrlPref = preferenceScreen.findPreference(getText(R.string.pref_key_use_custom_base_url)) as SwitchPreference?
+            useCustomBaseUrlPref?.let { enableCustomBaseUrlUI(it.isChecked) }
             useCustomBaseUrlPref?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
-                enableCustomBaseUrlUI( newValue as Boolean )
+                enableCustomBaseUrlUI(newValue as Boolean)
                 true
             }
-
         }
 
-        private fun enableCustomBaseUrlUI(boolean: Boolean){
+        private fun enableCustomBaseUrlUI(boolean: Boolean) {
             val ipAddressPref = preferenceScreen.findPreference(getText(R.string.pref_key_ip_addr)) as EditTextPreference?
             ipAddressPref?.isVisible = !boolean
             val portNumPref = preferenceScreen.findPreference(getText(R.string.pref_key_port_num)) as EditTextPreference?
@@ -114,43 +121,5 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
             val customBaseUrlPref = preferenceScreen.findPreference(getText(R.string.pref_key_custom_base_url)) as EditTextPreference?
             customBaseUrlPref?.isVisible = boolean
         }
-
-
-        companion object{
-        }
-
     }
-
-
-    companion object {
-        private const val PREFERENCE_RESOURCE_ID = "preferenceResource"
-        private const val PREFERENCE_ROOT = "root"
-
-        private const val IP_REGEX_PATTERN = """^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"""
-        private const val PORT_REGEX_PATTERN = """^([1-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"""
-
-        fun isPreferenceAllExists(context: Context):Boolean{
-            val pref = PreferenceManager.getDefaultSharedPreferences(context)
-            //IPアドレスの妥当性チェック
-            val ipRegEx = Regex(pattern =IP_REGEX_PATTERN)
-            val ipString = pref.getString(context.getString(R.string.pref_key_ip_addr),"")
-            if (ipString?.matches(ipRegEx) != true){
-                return false
-            }
-            //ポート番号の妥当性チェック
-            val portRegEx = Regex(pattern =PORT_REGEX_PATTERN)
-            val portString = pref.getString(context.getString(R.string.pref_key_port_num),"")
-            if (portString?.matches(portRegEx) != true){
-                return false
-            }
-            //ほかのパラメータの存在チェック
-            return (pref.contains(context.getString(R.string.pref_key_player)) &&
-                    pref.contains(context.getString(R.string.pref_key_num_of_history))&&
-                    pref.contains(context.getString(R.string.pref_key_use_custom_base_url))
-                    )
-        }
-
-    }
-
-
 }

--- a/app/src/main/res/drawable/ic_settings_connection.xml
+++ b/app/src/main/res/drawable/ic_settings_connection.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4V7H7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9H7c-1.71,0 -3.1,-1.39 -3.1,-3.1zM8,13h8v-2H8v2zM17,7h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1s-1.39,3.1 -3.1,3.1h-4V17h4c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_settings_image.xml
+++ b/app/src/main/res/drawable/ic_settings_image.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5L8.5,13.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_settings_player.xml
+++ b/app/src/main/res/drawable/ic_settings_player.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM10,16.5v-9l6,4.5L10,16.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_settings_reload.xml
+++ b/app/src/main/res/drawable/ic_settings_reload.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4c-3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4L17.65,6.35z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_settings_sort_asc.xml
+++ b/app/src/main/res/drawable/ic_settings_sort_asc.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Sort ascending: oldest first. Lines with an upward arrow indicator. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Sort lines (longest to shortest) -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M3,18h6v-2H3v2zM3,6v2h18V6H3zM3,13h12v-2H3v2z"/>
+    <!-- Up arrow at bottom right -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16,8.83V13h2V8.83l1.59,1.59L21,9l-4,-4l-4,4l1.41,1.41L16,8.83z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_settings_sort_desc.xml
+++ b/app/src/main/res/drawable/ic_settings_sort_desc.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Sort descending: newest first. Lines with a downward arrow indicator. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Sort lines (longest to shortest) -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M3,18h6v-2H3v2zM3,6v2h18V6H3zM3,13h12v-2H3v2z"/>
+    <!-- Down arrow at bottom right -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16,13v4.17l-1.59,-1.59L13,17l4,4l4,-4l-1.41,-1.41L18,17.17V13h-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_settings_unfold_less.xml
+++ b/app/src/main/res/drawable/ic_settings_unfold_less.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Unfold less: collapse rows (hide 0-recording rules that are visible) -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M7.41,18.59L8.83,20L12,16.83L15.17,20l1.41,-1.41L12,14L7.41,18.59zM16.59,5.41L15.17,4L12,7.17L8.83,4L7.41,5.41L12,10L16.59,5.41z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_settings_unfold_more.xml
+++ b/app/src/main/res/drawable/ic_settings_unfold_more.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Unfold more: expand rows (show hidden 0-recording rules) -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,5.83L15.17,9l1.41,-1.41L12,3L7.41,7.59L8.83,9L12,5.83zM12,18.17L8.83,15l-1.41,1.41L12,21l4.59,-4.59L15.17,15L12,18.17z"/>
+</vector>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/settings_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-    <fragment
-        android:id="@+id/settings_fragment"
-        android:name="com.daigorian.epcltvapp.SettingsFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</RelativeLayout>
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/item_settings_card.xml
+++ b/app/src/main/res/layout/item_settings_card.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:background="@color/default_background">
+
+    <ImageView
+        android:id="@+id/settings_card_icon"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="6"
+        android:padding="8dp"
+        android:scaleType="fitCenter" />
+
+    <TextView
+        android:id="@+id/settings_card_text"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="4"
+        android:textColor="@android:color/white"
+        android:textSize="12sp"
+        android:gravity="center"
+        android:maxLines="2"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp" />
+
+</LinearLayout>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -40,6 +40,21 @@
     <string name="program_name">番組名</string>
     <string name="set_newest_rule_first">録画ルールを新しい順に並べ替え</string>
     <string name="set_oldest_rule_first">録画ルールを古い順に並べ替え</string>
+
+    <!-- Settings card labels -->
+    <string name="settings_connection">接続設定</string>
+    <string name="settings_player">再生設定</string>
+    <string name="settings_card_sort_newest">ルール/履歴 新しい順</string>
+    <string name="settings_card_sort_oldest">ルール/履歴 古い順</string>
+    <string name="settings_card_bg_on">背景表示オン</string>
+    <string name="settings_card_bg_off">背景表示オフ</string>
+    <string name="settings_card_rules_show">0件ルール表示</string>
+    <string name="settings_card_rules_hide">0件ルール非表示</string>
+
+    <!-- Settings sub-screen titles -->
+    <string name="settings_connection_title">接続設定</string>
+    <string name="settings_player_title">再生設定</string>
+    <string name="show_thumbnail_background">番組選択画面でサムネイルを背景表示する</string>
     <string name="show_empty_rules">録画済み0件の録画ルールを表示する</string>
     <string name="use_custom_base_url">API Base URLを編集する</string>
     <string name="customize_base_url">API Base URL</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,22 @@
     <string name="search_history">Search history</string>
     <string name="program_name">Program Name</string>
 
+    <!-- Settings screen sub-screen keys -->
+    <string name="pref_key_screen_connection" translatable="false">pref_screen_connection</string>
+    <string name="pref_key_screen_player"     translatable="false">pref_screen_player</string>
+
+    <!-- Settings card labels -->
+    <string name="settings_connection">Connection</string>
+    <string name="settings_player">Playback Settings</string>
+    <string name="settings_connection_title">Connection Settings</string>
+    <string name="settings_player_title">Playback Settings</string>
+    <string name="settings_card_sort_newest">Rules: Newest</string>
+    <string name="settings_card_sort_oldest">Rules: Oldest</string>
+    <string name="settings_card_bg_on">Background ON</string>
+    <string name="settings_card_bg_off">Background OFF</string>
+    <string name="settings_card_rules_show">0-rec Rules: ON</string>
+    <string name="settings_card_rules_hide">0-rec Rules: OFF</string>
+
     <string name="pref_key_rules_order_is_newest_first"   translatable="false">KEY_RULES_ORDER_IS_NEWEST_FIRST</string>
     <string name="set_newest_rule_first">Newest rule first</string>
     <string name="set_oldest_rule_first">Oldest rule first</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,61 +2,63 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     app:title="@string/settings_title">
 
-    <EditTextPreference
-        app:title=       "@string/ip_addr_of_epgstation"
-        app:key=         "@string/pref_key_ip_addr"
-        app:defaultValue="@string/pref_val_ip_addr_default"
-        app:dialogLayout="@xml/preference_single_line_edittext"
-        app:useSimpleSummaryProvider="true"
-        />
-    <EditTextPreference
-        app:title=       "@string/port_number_of_epgstation"
-        app:key=         "@string/pref_key_port_num"
-        app:defaultValue="@string/pref_val_port_num_default"
-        app:dialogLayout="@xml/preference_single_line_edittext"
-        app:useSimpleSummaryProvider="true"
-        />
+    <PreferenceScreen
+        app:key="@string/pref_key_screen_connection"
+        app:title="@string/settings_connection">
 
-    <ListPreference
-        app:key=         "@string/pref_key_player"
-        app:defaultValue="@string/pref_val_player_default"
-        app:title=       "@string/movie_player"
-        app:entries=     "@array/pref_options_movie_player_label"
-        app:entryValues= "@array/pref_options_movie_player_val"
-        app:useSimpleSummaryProvider="true"
-        />
+        <EditTextPreference
+            app:title=       "@string/ip_addr_of_epgstation"
+            app:key=         "@string/pref_key_ip_addr"
+            app:defaultValue="@string/pref_val_ip_addr_default"
+            app:dialogLayout="@xml/preference_single_line_edittext"
+            app:useSimpleSummaryProvider="true"
+            />
 
-    <ListPreference
-        app:key=         "@string/pref_key_num_of_history"
-        app:defaultValue="@string/pref_val_num_of_history_default"
-        app:title=       "@string/num_of_history"
-        app:entries=     "@array/pref_options_num_of_history_label"
-        app:entryValues= "@array/pref_options_num_of_history_val"
-        app:useSimpleSummaryProvider="true"
-        />
+        <EditTextPreference
+            app:title=       "@string/port_number_of_epgstation"
+            app:key=         "@string/pref_key_port_num"
+            app:defaultValue="@string/pref_val_port_num_default"
+            app:dialogLayout="@xml/preference_single_line_edittext"
+            app:useSimpleSummaryProvider="true"
+            />
 
-    <SwitchPreference
-        app:key="@string/pref_key_show_thumbnail_background"
-        app:defaultValue="false"
-        app:title="@string/show_thumbnail_background" />
+        <SwitchPreference
+            app:key="@string/pref_key_use_custom_base_url"
+            app:defaultValue="false"
+            app:title="@string/use_custom_base_url" />
 
-    <SwitchPreference
-        app:key="@string/pref_key_show_empty_rules"
-        app:defaultValue="true"
-        app:title="@string/show_empty_rules" />
+        <EditTextPreference
+            app:title=       "@string/customize_base_url"
+            app:key=         "@string/pref_key_custom_base_url"
+            app:defaultValue="@string/pref_val_custom_base_url_default"
+            app:dialogLayout="@xml/preference_single_line_edittext"
+            app:useSimpleSummaryProvider="true"
+            />
 
-    <SwitchPreference
-        app:key="@string/pref_key_use_custom_base_url"
-        app:defaultValue="false"
-        app:title="@string/use_custom_base_url" />
+    </PreferenceScreen>
 
-    <EditTextPreference
-        app:title=       "@string/customize_base_url"
-        app:key=         "@string/pref_key_custom_base_url"
-        app:defaultValue="@string/pref_val_custom_base_url_default"
-        app:dialogLayout="@xml/preference_single_line_edittext"
-        app:useSimpleSummaryProvider="true"
-        />
+    <PreferenceScreen
+        app:key="@string/pref_key_screen_player"
+        app:title="@string/settings_player">
 
+        <ListPreference
+            app:key=         "@string/pref_key_player"
+            app:defaultValue="@string/pref_val_player_default"
+            app:title=       "@string/movie_player"
+            app:entries=     "@array/pref_options_movie_player_label"
+            app:entryValues= "@array/pref_options_movie_player_val"
+            app:useSimpleSummaryProvider="true"
+            />
+
+        <ListPreference
+            app:key=         "@string/pref_key_num_of_history"
+            app:defaultValue="@string/pref_val_num_of_history_default"
+            app:title=       "@string/num_of_history"
+            app:entries=     "@array/pref_options_num_of_history_label"
+            app:entryValues= "@array/pref_options_num_of_history_val"
+            app:useSimpleSummaryProvider="true"
+            />
+
+    </PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
## Summary

- メイン画面の最下行に、アイコン＋テキストの設定カードを横並びで表示するよう設定画面をリデザイン
- 接続設定・再生設定は各サブ画面（`PreferenceScreen`）に直接遷移
- 並び順・背景表示・0件ルール表示トグルはインラインで状態変更しフォーカスを保持
- 再読み込みボタンはコンテンツ行のみ更新（設定行のフォーカスを維持）
- 接続設定から戻った際、設定値が変わった場合のみ再接続・再読み込みを実施

## 変更ファイル

- `SettingsCardPresenter.kt` (新規) — アイコン+テキストのカード Presenter
- `item_settings_card.xml` (新規) — カードレイアウト
- `ic_settings_*.xml` (新規×8) — 各設定アクション用 Vector drawable
- `MainFragment.kt` — 設定カード行の追加・クリックハンドラー・`reloadContentRows()` 等
- `SettingsActivity.kt` / `SettingsFragment.kt` — サブ画面への直接遷移対応
- `activity_settings.xml` — `<fragment>` → `<FrameLayout>` に変更（引数付きフラグメント差し替えのため）
- `preferences.xml` — 接続／再生の2サブスクリーンに分割
- `strings.xml` / `strings-ja-rJP.xml` — 設定カード用文字列追加

## Test plan

- [x] 初回起動時に接続設定画面が開くこと
- [x] 接続設定カード → 接続設定サブ画面に直接遷移すること
- [x] 再生設定カード → 再生設定サブ画面に直接遷移すること（戻り時にコンテンツ再読み込みしないこと）
- [x] 接続設定を変更して戻ると再接続・再読み込みされること
- [x] 接続設定を変更せずに戻ると再読み込みされないこと
- [x] 再読み込みカード → コンテンツ行のみ更新・設定行のフォーカスが保たれること
- [x] 並び順トグル → ルール行が即座に並び替わり・フォーカス維持
- [x] 背景表示トグル → 背景表示が即座に切り替わり・フォーカス維持
- [x] 0件ルール表示トグル → ルール行の表示/非表示が切り替わり・フォーカス維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)