### PR TITLE
feat: 番組情報ダイアログ・チャンネル名・ジャンル表示

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/AribGenre.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/AribGenre.kt
@@ -1,0 +1,70 @@
+package com.daigorian.epcltvapp
+
+object AribGenre {
+    fun getGenreText(genre: Long?, subGenre: Long?): String {
+        if (genre == null) return ""
+        val main = mainNames[genre.toInt()] ?: return ""
+        val sub = subGenre?.let { subNames[genre.toInt()]?.get(it.toInt())?.takeIf { s -> s.isNotEmpty() } }
+        return if (sub != null) "$main / $sub" else main
+    }
+
+    private val mainNames = mapOf(
+        0 to "ニュース・報道",
+        1 to "スポーツ",
+        2 to "情報・ワイドショー",
+        3 to "ドラマ",
+        4 to "音楽",
+        5 to "バラエティ",
+        6 to "映画",
+        7 to "アニメ・特撮",
+        8 to "ドキュメンタリー・教養",
+        9 to "劇場・公演",
+        10 to "趣味・教育",
+        11 to "福祉",
+        15 to "その他"
+    )
+
+    private val subNames = mapOf(
+        0 to mapOf(
+            0 to "定時・総合", 1 to "天気", 2 to "特集・ドキュメント", 3 to "政治・国会",
+            4 to "経済・市況", 5 to "海外・国際", 6 to "解説", 7 to "討論・会談",
+            8 to "報道特番", 9 to "ローカル・地域", 10 to "交通", 15 to "その他"),
+        1 to mapOf(
+            0 to "スポーツニュース", 1 to "野球", 2 to "サッカー", 3 to "ゴルフ",
+            4 to "その他の球技", 5 to "相撲・格闘技", 6 to "オリンピック・国際大会",
+            7 to "マラソン・陸上・水泳", 8 to "モータースポーツ",
+            9 to "マリン・ウィンタースポーツ", 10 to "競馬・公営競技", 15 to "その他"),
+        2 to mapOf(
+            0 to "芸能・ワイドショー", 1 to "ファッション", 2 to "暮らし・住まい",
+            3 to "健康・医療", 4 to "ショッピング・通販", 5 to "グルメ・料理",
+            6 to "イベント", 7 to "番組紹介・お知らせ", 15 to "その他"),
+        3 to mapOf(0 to "国内ドラマ", 1 to "海外ドラマ", 2 to "時代劇", 15 to "その他"),
+        4 to mapOf(
+            0 to "国内ロック・ポップス", 1 to "海外ロック・ポップス", 2 to "クラシック・オペラ",
+            3 to "ジャズ・フュージョン", 4 to "歌謡曲・演歌", 5 to "ライブ・コンサート",
+            6 to "ランキング・リクエスト", 7 to "カラオケ・のど自慢", 8 to "民謡・邦楽",
+            9 to "童謡・キッズ", 10 to "民族音楽・ワールドミュージック", 15 to "その他"),
+        5 to mapOf(
+            0 to "クイズ", 1 to "ゲーム", 2 to "トークバラエティ", 3 to "お笑い・コメディ",
+            4 to "音楽バラエティ", 5 to "旅バラエティ", 6 to "料理バラエティ", 15 to "その他"),
+        6 to mapOf(0 to "洋画", 1 to "邦画", 2 to "アニメ", 15 to "その他"),
+        7 to mapOf(0 to "国内アニメ", 1 to "海外アニメ", 2 to "特撮", 15 to "その他"),
+        8 to mapOf(
+            0 to "社会・時事", 1 to "歴史・紀行", 2 to "自然・動物・環境",
+            3 to "宇宙・科学・医学", 4 to "カルチャー・伝統文化", 5 to "文学・文芸",
+            6 to "スポーツ", 7 to "ドキュメンタリー全般", 8 to "インタビュー・討論", 15 to "その他"),
+        9 to mapOf(
+            0 to "現代劇・新劇", 1 to "ミュージカル", 2 to "ダンス・バレエ",
+            3 to "落語・演芸", 4 to "歌舞伎・古典", 15 to "その他"),
+        10 to mapOf(
+            0 to "旅・釣り・アウトドア", 1 to "園芸・ペット・手芸", 2 to "音楽・美術・工芸",
+            3 to "囲碁・将棋", 4 to "麻雀・パチンコ", 5 to "車・オートバイ",
+            6 to "コンピュータ・ＴＶゲーム", 7 to "会話・語学", 8 to "幼児・小学生",
+            9 to "中学生・高校生", 10 to "大学生・受験", 11 to "生涯教育・資格",
+            12 to "教育問題", 15 to "その他"),
+        11 to mapOf(
+            0 to "高齢者", 1 to "障害者", 2 to "社会福祉", 3 to "ボランティア",
+            4 to "手話", 5 to "文字(字幕)", 6 to "音声解説", 15 to "その他"),
+        15 to mapOf(15 to "その他")
+    )
+}

--- a/app/src/main/java/com/daigorian/epcltvapp/DetailsDescriptionPresenter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/DetailsDescriptionPresenter.kt
@@ -189,8 +189,9 @@ class DetailsDescriptionPresenter : Presenter() {
     ) {
         val context = viewHolder.view.context
 
-        val dfDateAndTime = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.SHORT)
-        val dfTime = DateFormat.getTimeInstance(DateFormat.SHORT)
+        val jst = TimeZone.getTimeZone("Asia/Tokyo")
+        val dfDateAndTime = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.SHORT).also { it.timeZone = jst }
+        val dfTime = DateFormat.getTimeInstance(DateFormat.SHORT).also { it.timeZone = jst }
 
         if ( item is RecordedProgram) {
 
@@ -198,12 +199,12 @@ class DetailsDescriptionPresenter : Presenter() {
             val endAt = dfTime.format(Date(item.endAt))
             val duration =  (item.endAt - item.startAt) / 60 / 1000
             val recTimeInfo = context.getString(R.string.start_end_duration,startAt,endAt,duration)
-            // 日本語 locale   : recTimeInfo == "2022年1月4日 14:00 ～ 14:30 (30分)"
-            // English locale : recTimeInfo == "January 4, 2022 2:00 PM - 2:30 PM (30 min.)"
+            val channelName = EpgStation.channelMap[item.channelId] ?: ""
+            val channelAndTime = if (channelName.isNotEmpty()) "$channelName　$recTimeInfo" else recTimeInfo
 
             viewHolder.title.text = item.name
             viewHolder.subtitle.text = item.description.orEmpty()
-            viewHolder.body.text = recTimeInfo + "\n" +
+            viewHolder.body.text = channelAndTime + "\n" +
                     item.extended.orEmpty()
 
         }else if ( item is RecordedItem) {
@@ -212,12 +213,12 @@ class DetailsDescriptionPresenter : Presenter() {
             val endAt = dfTime.format(Date(item.endAt))
             val duration =  (item.endAt - item.startAt) / 60 / 1000
             val recTimeInfo = context.getString(R.string.start_end_duration,startAt,endAt,duration)
-            // 日本語 locale   : recTimeInfo == "2022年1月4日 14:00 ～ 14:30 (30分)"
-            // English locale : recTimeInfo == "January 4, 2022 2:00 PM - 2:30 PM (30 min.)"
+            val channelName = item.channelId?.let { EpgStationV2.channelMap[it] } ?: ""
+            val channelAndTime = if (channelName.isNotEmpty()) "$channelName　$recTimeInfo" else recTimeInfo
 
             viewHolder.title.text = item.name
             viewHolder.subtitle.text = item.description.orEmpty()
-            viewHolder.body.text = recTimeInfo + "\n" +
+            viewHolder.body.text = channelAndTime + "\n" +
                     item.extended.orEmpty()
         }
     }

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -229,12 +229,14 @@ class MainFragment : BrowseSupportFragment() {
                             //Version 2で初期化
                             Log.d(TAG, "initEPGStationApi() detect Version 2.x.x")
                             EpgStationV2.initAPI(baseUrl)
+                            EpgStationV2.fetchChannels()
                             loadRows()
                         } else {
                             //Version 1で初期化
                             Log.d(TAG, "initEPGStationApi() detect Version 1.x.x")
                             EpgStationV2.api = null
                             EpgStation.initAPI(baseUrl)
+                            EpgStation.fetchChannels()
                             loadRows()
                         }
                     }

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -61,6 +61,8 @@ class MainFragment : BrowseSupportFragment() {
         when (key) {
             getString(R.string.pref_key_rules_order_is_newest_first) -> {
                 if (isResumed) {
+                    Log.d(TAG, "prefChanged: rules_order → setSelectedPosition(0) before deleteCategory")
+                    setSelectedPosition(0, false)
                     Log.d(TAG, "prefChanged: rules_order → deleteCategory(RECORDED_BY_RULES+SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                     mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
                     mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
@@ -89,6 +91,8 @@ class MainFragment : BrowseSupportFragment() {
             }
             "pref_key_search_histories" -> {
                 if (isResumed) {
+                    Log.d(TAG, "prefChanged: search_histories → setSelectedPosition(0) before deleteCategory")
+                    setSelectedPosition(0, false)
                     Log.d(TAG, "prefChanged: search_histories cleared → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                     mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
                     Log.d(TAG, "prefChanged: search_histories after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
@@ -156,6 +160,8 @@ class MainFragment : BrowseSupportFragment() {
                 Log.d(TAG, "onResume: branch=reloadHistory → deferring to view.post")
                 mNeedsReloadHistoryOnResume = false
                 view?.post {
+                    Log.d(TAG, "onResume: reloadHistory deferred → setSelectedPosition(0) adapterSize=${mMainMenuAdapter.size()}")
+                    setSelectedPosition(0, false)
                     Log.d(TAG, "onResume: reloadHistory deferred → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                     mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
                     Log.d(TAG, "onResume: reloadHistory deferred → after deleteCategory adapterSize=${mMainMenuAdapter.size()}")

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -408,6 +408,7 @@ class MainFragment : BrowseSupportFragment() {
             override fun onResponse(call: Call<List<RuleList>>, response: Response<List<RuleList>>) {
                 response.body()?.let{ it ->
                     val rules = if(isNewestFirst){it.reversed()}else{it}
+                    val orderedIds = rules.map { rule -> rule.id.toLong() }
                     rules.forEach { rule ->
 
                         //録画ルールにキーワードが設定されていない場合、キーワードの代わりにルールIDをセット
@@ -421,7 +422,8 @@ class MainFragment : BrowseSupportFragment() {
                             GetRecordedParamV2(ruleId= rule.id),
                             keyword,
                             Category.RECORDED_BY_RULES,
-                            rule.id
+                            rule.id,
+                            orderedIds
                         )
                     }
                 }
@@ -435,6 +437,7 @@ class MainFragment : BrowseSupportFragment() {
             override fun onResponse(call: Call<Rules>, response: Response<Rules>) {
                 response.body()?.rules?.let{ it ->
                     val rules = if(isNewestFirst){it.reversed()}else{it}
+                    val orderedIds = rules.map { rule -> rule.id.toLong() }
                     rules.forEach { rule ->
 
                         //録画ルールにキーワードが設定されていない場合、キーワードの代わりにルールIDをセット
@@ -448,7 +451,8 @@ class MainFragment : BrowseSupportFragment() {
                             GetRecordedParamV2(ruleId= rule.id),
                             keyword,
                             Category.RECORDED_BY_RULES,
-                            rule.id
+                            rule.id,
+                            orderedIds
                         )
                     }
                 }
@@ -863,7 +867,7 @@ class MainFragment : BrowseSupportFragment() {
             }
         }
 
-        fun updateContentsListRowWithCategory(v1Pram:GetRecordedParam,v2Param:GetRecordedParamV2,title:String,category:Category,idInCategory:Long){
+        fun updateContentsListRowWithCategory(v1Pram:GetRecordedParam,v2Param:GetRecordedParamV2,title:String,category:Category,idInCategory:Long,orderedIds:List<Long>?=null){
 
             val headerId = category.ordinal.toLong()*10000 + idInCategory
 
@@ -954,7 +958,11 @@ class MainFragment : BrowseSupportFragment() {
                             if (getRecordedResponse.total == 0L && !showEmptyRules) {
                                 return@let  // 空ルールは非表示のままスキップ
                             }
-                            addToCategory(category, ListRow(HeaderItem(headerId, title), listRowAdapter))
+                            if (orderedIds != null) {
+                                addToCategoryOrdered(category, ListRow(HeaderItem(headerId, title), listRowAdapter), idInCategory, orderedIds)
+                            } else {
+                                addToCategory(category, ListRow(HeaderItem(headerId, title), listRowAdapter))
+                            }
                         }
 
                         // 録画0件かつ設定がOFFの場合は既存ルール行を非表示にする
@@ -1026,7 +1034,11 @@ class MainFragment : BrowseSupportFragment() {
                             if (getRecordedResponse.total == 0 && !showEmptyRules) {
                                 return@let  // 空ルールは非表示のままスキップ
                             }
-                            addToCategory(category, ListRow(HeaderItem(headerId, title), listRowAdapter))
+                            if (orderedIds != null) {
+                                addToCategoryOrdered(category, ListRow(HeaderItem(headerId, title), listRowAdapter), idInCategory, orderedIds)
+                            } else {
+                                addToCategory(category, ListRow(HeaderItem(headerId, title), listRowAdapter))
+                            }
                         }
 
                         // 録画0件かつ設定がOFFの場合は既存ルール行を非表示にする
@@ -1066,37 +1078,29 @@ class MainFragment : BrowseSupportFragment() {
             emptyIds.forEach { removeRowFromCategory(Category.RECORDED_BY_RULES, it) }
         }
 
-        fun sortRulesByRecordedDate(){
-            synchronized(this){
-                //bubble sort で新しいのを下からあげていく
-                val startIndex = numOfRowInCategory.copyOfRange (0,Category.RECORDED_BY_RULES.ordinal).sum() +3
-                val endIndex = numOfRowInCategory.copyOfRange(0,Category.RECORDED_BY_RULES.ordinal+1).sum() -1
-                for(i in startIndex until endIndex){
-                    for(j in endIndex downTo i){
-                        //下のアイテムJ
-                        val itemJ = (get(j) as? ListRow)?.adapter
-                        //上のアイテムJ-1
-                        val itemJMinus1 = (get(j-1) as? ListRow)?.adapter
-
-                        if (itemJ != null && itemJ.size() >0){
-                            //下のアイテムに録画済の要素がある
-
-                            if (itemJMinus1 != null && itemJMinus1.size() >0) {
-                                //上のアイテムに録画済の要素がある
-                                //TODO :  EPGStation V2(RecordedItem) への対応
-                                val startTimeOfJ = (itemJ.get(0) as? RecordedProgram)?.startAt
-                                val startTimeOfJMinus1 = (itemJMinus1.get(0) as? RecordedProgram)?.startAt
-                                //下のアイテムが上のアイテムより録画時間が新しい
-                                if (startTimeOfJ != null && startTimeOfJMinus1 != null && startTimeOfJ > startTimeOfJMinus1) {
-                                    move(j, j - 1)
-                                }
-                            }else{
-                                //上のアイテムに録画済の要素がない
-                                move(j, j - 1)
-                            }
-                        }
+        fun addToCategoryOrdered(cat: Category, item: Any, idInCategory: Long, orderedIds: List<Long>) {
+            synchronized(this) {
+                if (numOfRowInCategory[cat.ordinal] == 0) {
+                    addToCategory(cat, item)
+                    return
+                }
+                val myOrderIndex = orderedIds.indexOf(idInCategory)
+                val catStart = numOfRowInCategory.copyOfRange(0, cat.ordinal).sum()
+                val headerRows = 2 // DividerRow + SectionRow
+                val ruleStart = catStart + headerRows
+                val ruleEnd = catStart + numOfRowInCategory[cat.ordinal]
+                var insertPos = ruleEnd
+                for (i in ruleStart until ruleEnd) {
+                    val row = get(i) as? ListRow ?: continue
+                    val existingId = row.headerItem.id - cat.ordinal.toLong() * 10000
+                    val existingOrderIndex = orderedIds.indexOf(existingId)
+                    if (myOrderIndex != -1 && (existingOrderIndex == -1 || existingOrderIndex > myOrderIndex)) {
+                        insertPos = i
+                        break
                     }
                 }
+                super.add(insertPos, item)
+                numOfRowInCategory[cat.ordinal]++
             }
         }
 

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -59,19 +59,29 @@ class MainFragment : BrowseSupportFragment() {
     private val mDisplayPrefChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
         when (key) {
             getString(R.string.pref_key_rules_order_is_newest_first) -> {
-                mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
-                updateRows()
+                // isResumed チェック: SettingsActivity は透過テーマのため MainFragment は onPause のまま残る。
+                // onPause 中に行削除を行うと Leanback の SetSelectionRunnable が保存済み位置で crash するため、
+                // その場合は onResume の else -> updateRows() に委ねる。
+                if (isResumed) {
+                    mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
+                    updateRows()
+                }
             }
             getString(R.string.pref_key_show_thumbnail_background) -> {
+                // 行数変化なし。onPause 中でも安全にリアルタイム反映できる。
                 startBackgroundTimer()
             }
             getString(R.string.pref_key_show_empty_rules) -> {
-                val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
-                if (showEmptyRules) updateRows() else mMainMenuAdapter.removeEmptyRuleRows()
+                if (isResumed) {
+                    val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+                    if (showEmptyRules) updateRows() else mMainMenuAdapter.removeEmptyRuleRows()
+                }
             }
             "pref_key_search_histories" -> {
-                mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
-                updateRows()
+                if (isResumed) {
+                    mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
+                    updateRows()
+                }
             }
         }
     }

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -57,34 +57,42 @@ class MainFragment : BrowseSupportFragment() {
     private val mMainMenuAdapter = MainMenuAdapter(mMainMenuListRowPresenter)
 
     private val mDisplayPrefChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
+        Log.d(TAG, "prefChanged key=$key isResumed=$isResumed adapterSize=${mMainMenuAdapter.size()} selectedPos=$selectedPosition")
         when (key) {
             getString(R.string.pref_key_rules_order_is_newest_first) -> {
-                // isResumed チェック: SettingsActivity は透過テーマのため MainFragment は onPause のまま残る。
-                // onPause 中に行削除を行うと Leanback の SetSelectionRunnable が保存済み位置で crash するため、
-                // その場合は onResume の else -> updateRows() に委ねる。
                 if (isResumed) {
+                    Log.d(TAG, "prefChanged: rules_order → deleteCategory(RECORDED_BY_RULES) before=${mMainMenuAdapter.size()}")
                     mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
+                    Log.d(TAG, "prefChanged: rules_order → after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
                     updateRows()
+                } else {
+                    Log.d(TAG, "prefChanged: rules_order skipped (not resumed)")
                 }
             }
             getString(R.string.pref_key_show_thumbnail_background) -> {
-                // 行数変化なし。onPause 中でも安全にリアルタイム反映できる。
                 startBackgroundTimer()
             }
             getString(R.string.pref_key_show_empty_rules) -> {
                 if (isResumed) {
                     val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+                    Log.d(TAG, "prefChanged: show_empty_rules=$showEmptyRules adapterSize=${mMainMenuAdapter.size()}")
                     if (showEmptyRules) updateRows() else mMainMenuAdapter.removeEmptyRuleRows()
+                } else {
+                    Log.d(TAG, "prefChanged: show_empty_rules skipped (not resumed)")
                 }
             }
             getString(R.string.pref_key_num_of_history) -> {
-                // 件数変更は onResume で deleteCategory → updateRows() に委ねる
+                Log.d(TAG, "prefChanged: num_of_history → mNeedsReloadHistoryOnResume=true")
                 mNeedsReloadHistoryOnResume = true
             }
             "pref_key_search_histories" -> {
                 if (isResumed) {
+                    Log.d(TAG, "prefChanged: search_histories cleared → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                     mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
+                    Log.d(TAG, "prefChanged: search_histories after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
                     updateRows()
+                } else {
+                    Log.d(TAG, "prefChanged: search_histories skipped (not resumed)")
                 }
             }
         }
@@ -125,43 +133,52 @@ class MainFragment : BrowseSupportFragment() {
     }
 
     override fun onResume() {
-        Log.i(TAG, "onResume")
+        Log.i(TAG, "onResume adapterSize=${mMainMenuAdapter.size()} selectedPos=$selectedPosition flags[reloadAll=$mNeedsReloadAllOnResume conn=$mNeedsCheckConnectionOnResume hist=$mNeedsReloadHistoryOnResume]")
         super.onResume()
+        Log.d(TAG, "onResume after super: adapterSize=${mMainMenuAdapter.size()} selectedPos=$selectedPosition")
         when {
             mNeedsReloadAllOnResume && SettingsFragment.isPreferenceAllExists(requireContext()) -> {
-                // 初回起動など、接続設定が揃った後のフル初期化
+                Log.d(TAG, "onResume: branch=reloadAll")
                 initEPGStationApi()
                 mNeedsReloadAllOnResume = false
             }
             mNeedsCheckConnectionOnResume -> {
-                // 接続設定から戻ってきた場合、設定値が変わっていれば再接続
+                val changed = connectionKey() != mConnectionKeyBeforeSettings
+                Log.d(TAG, "onResume: branch=checkConnection changed=$changed")
                 mNeedsCheckConnectionOnResume = false
-                if (connectionKey() != mConnectionKeyBeforeSettings) {
+                if (changed) {
                     initEPGStationApi()
                 }
-                // 変わっていなければ何もしない
             }
             mNeedsReloadHistoryOnResume -> {
-                // 履歴行の読み直し
+                Log.d(TAG, "onResume: branch=reloadHistory → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                 mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
+                Log.d(TAG, "onResume: after deleteCategory(SEARCH_HISTORY) adapterSize=${mMainMenuAdapter.size()}")
                 updateRows()
                 mNeedsReloadHistoryOnResume = false
             }
             else -> {
+                Log.d(TAG, "onResume: branch=else → updateRows")
                 updateRows()
             }
         }
+    }
 
+    override fun onPause() {
+        super.onPause()
+        Log.d(TAG, "onPause: adapterSize=${mMainMenuAdapter.size()} selectedPos=$selectedPosition")
     }
 
     override fun onStart() {
         super.onStart()
+        Log.d(TAG, "onStart: registering prefListener adapterSize=${mMainMenuAdapter.size()}")
         PreferenceManager.getDefaultSharedPreferences(requireContext())
             .registerOnSharedPreferenceChangeListener(mDisplayPrefChangeListener)
     }
 
     override fun onStop() {
         super.onStop()
+        Log.d(TAG, "onStop: unregistering prefListener adapterSize=${mMainMenuAdapter.size()}")
         PreferenceManager.getDefaultSharedPreferences(requireContext())
             .unregisterOnSharedPreferenceChangeListener(mDisplayPrefChangeListener)
     }

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -61,7 +61,7 @@ class MainFragment : BrowseSupportFragment() {
         when (key) {
             getString(R.string.pref_key_rules_order_is_newest_first) -> {
                 Log.d(TAG, "prefChanged: rules_order → setSelectedPosition(0) before deleteCategory")
-                setSelectedPosition(0, false)
+                setSelectedPosition(mMainMenuAdapter.size() - 1, false)
                 Log.d(TAG, "prefChanged: rules_order → deleteCategory(RECORDED_BY_RULES+SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                 mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
                 mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
@@ -74,18 +74,18 @@ class MainFragment : BrowseSupportFragment() {
             getString(R.string.pref_key_show_empty_rules) -> {
                 val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
                 Log.d(TAG, "prefChanged: show_empty_rules=$showEmptyRules adapterSize=${mMainMenuAdapter.size()}")
-                setSelectedPosition(0, false)
+                setSelectedPosition(mMainMenuAdapter.size() - 1, false)
                 if (showEmptyRules) updateRows() else mMainMenuAdapter.removeEmptyRuleRows()
             }
             getString(R.string.pref_key_num_of_history) -> {
                 Log.d(TAG, "prefChanged: num_of_history → setSelectedPosition(0) + deleteCategory(SEARCH_HISTORY)")
-                setSelectedPosition(0, false)
+                setSelectedPosition(mMainMenuAdapter.size() - 1, false)
                 mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
                 updateRows()
             }
             "pref_key_search_histories" -> {
                 Log.d(TAG, "prefChanged: search_histories → setSelectedPosition(0) before deleteCategory")
-                setSelectedPosition(0, false)
+                setSelectedPosition(mMainMenuAdapter.size() - 1, false)
                 Log.d(TAG, "prefChanged: search_histories cleared → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                 mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
                 Log.d(TAG, "prefChanged: search_histories after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
@@ -151,7 +151,7 @@ class MainFragment : BrowseSupportFragment() {
                 mNeedsReloadHistoryOnResume = false
                 view?.post {
                     Log.d(TAG, "onResume: reloadHistory deferred → setSelectedPosition(0) adapterSize=${mMainMenuAdapter.size()}")
-                    setSelectedPosition(0, false)
+                    setSelectedPosition(mMainMenuAdapter.size() - 1, false)
                     Log.d(TAG, "onResume: reloadHistory deferred → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                     mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
                     Log.d(TAG, "onResume: reloadHistory deferred → after deleteCategory adapterSize=${mMainMenuAdapter.size()}")

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -98,7 +98,8 @@ class MainFragment : BrowseSupportFragment() {
                     Log.d(TAG, "prefChanged: search_histories after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
                     updateRows()
                 } else {
-                    Log.d(TAG, "prefChanged: search_histories skipped (not resumed)")
+                    Log.d(TAG, "prefChanged: search_histories (not resumed) → mNeedsReloadHistoryOnResume=true")
+                    mNeedsReloadHistoryOnResume = true
                 }
             }
         }

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -61,7 +61,7 @@ class MainFragment : BrowseSupportFragment() {
         when (key) {
             getString(R.string.pref_key_rules_order_is_newest_first) -> {
                 Log.d(TAG, "prefChanged: rules_order → setSelectedPosition(0) before deleteCategory")
-                setSelectedPosition(mMainMenuAdapter.size() - 1, false)
+                setSelectedPosition(0, false)
                 Log.d(TAG, "prefChanged: rules_order → deleteCategory(RECORDED_BY_RULES+SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                 mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
                 mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
@@ -74,18 +74,18 @@ class MainFragment : BrowseSupportFragment() {
             getString(R.string.pref_key_show_empty_rules) -> {
                 val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
                 Log.d(TAG, "prefChanged: show_empty_rules=$showEmptyRules adapterSize=${mMainMenuAdapter.size()}")
-                setSelectedPosition(mMainMenuAdapter.size() - 1, false)
+                setSelectedPosition(0, false)
                 if (showEmptyRules) updateRows() else mMainMenuAdapter.removeEmptyRuleRows()
             }
             getString(R.string.pref_key_num_of_history) -> {
                 Log.d(TAG, "prefChanged: num_of_history → setSelectedPosition(0) + deleteCategory(SEARCH_HISTORY)")
-                setSelectedPosition(mMainMenuAdapter.size() - 1, false)
+                setSelectedPosition(0, false)
                 mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
                 updateRows()
             }
             "pref_key_search_histories" -> {
                 Log.d(TAG, "prefChanged: search_histories → setSelectedPosition(0) before deleteCategory")
-                setSelectedPosition(mMainMenuAdapter.size() - 1, false)
+                setSelectedPosition(0, false)
                 Log.d(TAG, "prefChanged: search_histories cleared → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                 mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
                 Log.d(TAG, "prefChanged: search_histories after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
@@ -151,7 +151,7 @@ class MainFragment : BrowseSupportFragment() {
                 mNeedsReloadHistoryOnResume = false
                 view?.post {
                     Log.d(TAG, "onResume: reloadHistory deferred → setSelectedPosition(0) adapterSize=${mMainMenuAdapter.size()}")
-                    setSelectedPosition(mMainMenuAdapter.size() - 1, false)
+                    setSelectedPosition(0, false)
                     Log.d(TAG, "onResume: reloadHistory deferred → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                     mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
                     Log.d(TAG, "onResume: reloadHistory deferred → after deleteCategory adapterSize=${mMainMenuAdapter.size()}")

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -77,6 +77,10 @@ class MainFragment : BrowseSupportFragment() {
                     if (showEmptyRules) updateRows() else mMainMenuAdapter.removeEmptyRuleRows()
                 }
             }
+            getString(R.string.pref_key_num_of_history) -> {
+                // 件数変更は onResume で deleteCategory → updateRows() に委ねる
+                mNeedsReloadHistoryOnResume = true
+            }
             "pref_key_search_histories" -> {
                 if (isResumed) {
                     mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -4,6 +4,7 @@ import com.daigorian.epcltvapp.epgstationcaller.*
 import com.daigorian.epcltvapp.epgstationv2caller.*
 
 import android.content.Intent
+import android.content.SharedPreferences
 import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.os.Build
@@ -54,6 +55,26 @@ class MainFragment : BrowseSupportFragment() {
     private val mCardPresenter = OriginalCardPresenter()
     private val mMainMenuListRowPresenter = ListRowPresenter()
     private val mMainMenuAdapter = MainMenuAdapter(mMainMenuListRowPresenter)
+
+    private val mDisplayPrefChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
+        when (key) {
+            getString(R.string.pref_key_rules_order_is_newest_first) -> {
+                mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
+                updateRows()
+            }
+            getString(R.string.pref_key_show_thumbnail_background) -> {
+                startBackgroundTimer()
+            }
+            getString(R.string.pref_key_show_empty_rules) -> {
+                val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+                if (showEmptyRules) updateRows() else mMainMenuAdapter.removeEmptyRuleRows()
+            }
+            "pref_key_search_histories" -> {
+                mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
+                updateRows()
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.i(TAG, "onCreate")
@@ -117,6 +138,18 @@ class MainFragment : BrowseSupportFragment() {
             }
         }
 
+    }
+
+    override fun onStart() {
+        super.onStart()
+        PreferenceManager.getDefaultSharedPreferences(requireContext())
+            .registerOnSharedPreferenceChangeListener(mDisplayPrefChangeListener)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        PreferenceManager.getDefaultSharedPreferences(requireContext())
+            .unregisterOnSharedPreferenceChangeListener(mDisplayPrefChangeListener)
     }
 
     override fun onDestroy() {
@@ -408,8 +441,6 @@ class MainFragment : BrowseSupportFragment() {
         val gridRowAdapter = ArrayObjectAdapter(gridPresenter)
         mSettingsRowAdapter = gridRowAdapter
 
-        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-
         gridRowAdapter.add(SettingsCardPresenter.Item(
             R.drawable.ic_settings_connection,
             getString(R.string.settings_connection),
@@ -421,31 +452,14 @@ class MainFragment : BrowseSupportFragment() {
             SettingsCardPresenter.Item.Action.PLAYER
         ))
         gridRowAdapter.add(SettingsCardPresenter.Item(
+            R.drawable.ic_settings_image,
+            getString(R.string.settings_display),
+            SettingsCardPresenter.Item.Action.DISPLAY
+        ))
+        gridRowAdapter.add(SettingsCardPresenter.Item(
             R.drawable.ic_settings_reload,
             getString(R.string.reload),
             SettingsCardPresenter.Item.Action.RELOAD
-        ))
-
-        // ラベル・アイコンはクリック後に得られる状態を表す
-        val isNewestFirst = prefs.getBoolean(getString(R.string.pref_key_rules_order_is_newest_first), false)
-        gridRowAdapter.add(SettingsCardPresenter.Item(
-            if (isNewestFirst) R.drawable.ic_settings_sort_asc else R.drawable.ic_settings_sort_desc,
-            if (isNewestFirst) getString(R.string.settings_card_sort_oldest) else getString(R.string.settings_card_sort_newest),
-            SettingsCardPresenter.Item.Action.RULES_ORDER
-        ))
-
-        val showBg = prefs.getBoolean(getString(R.string.pref_key_show_thumbnail_background), false)
-        gridRowAdapter.add(SettingsCardPresenter.Item(
-            R.drawable.ic_settings_image,
-            if (showBg) getString(R.string.settings_card_bg_off) else getString(R.string.settings_card_bg_on),
-            SettingsCardPresenter.Item.Action.BACKGROUND
-        ))
-
-        val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
-        gridRowAdapter.add(SettingsCardPresenter.Item(
-            if (showEmptyRules) R.drawable.ic_settings_unfold_less else R.drawable.ic_settings_unfold_more,
-            if (showEmptyRules) getString(R.string.settings_card_rules_hide) else getString(R.string.settings_card_rules_show),
-            SettingsCardPresenter.Item.Action.EMPTY_RULES
         ))
 
         mMainMenuAdapter.addToCategory(Category.SETTINGS, ListRow(gridHeader, gridRowAdapter))
@@ -526,7 +540,6 @@ class MainFragment : BrowseSupportFragment() {
                     startActivity(intent, bundle)
                 }
                 is SettingsCardPresenter.Item -> {
-                    val prefs = PreferenceManager.getDefaultSharedPreferences(context)
                     when (item.action) {
                         SettingsCardPresenter.Item.Action.CONNECTION -> {
                             mConnectionKeyBeforeSettings = connectionKey()
@@ -536,51 +549,17 @@ class MainFragment : BrowseSupportFragment() {
                             startActivity(intent)
                         }
                         SettingsCardPresenter.Item.Action.PLAYER -> {
-                            // 再生設定はコンテンツリストに影響しないので戻り時に再読み込みしない
                             val intent = Intent(context!!, SettingsActivity::class.java)
                             intent.putExtra(SettingsActivity.EXTRA_START_SCREEN, getString(R.string.pref_key_screen_player))
                             startActivity(intent)
                         }
+                        SettingsCardPresenter.Item.Action.DISPLAY -> {
+                            val intent = Intent(context!!, SettingsActivity::class.java)
+                            intent.putExtra(SettingsActivity.EXTRA_START_SCREEN, getString(R.string.pref_key_screen_display))
+                            startActivity(intent)
+                        }
                         SettingsCardPresenter.Item.Action.RELOAD -> {
                             reloadContentRows()
-                        }
-                        SettingsCardPresenter.Item.Action.RULES_ORDER -> {
-                            val isNewestFirst = prefs.getBoolean(getString(R.string.pref_key_rules_order_is_newest_first), false)
-                            val newIsNewestFirst = !isNewestFirst
-                            prefs.edit().putBoolean(getString(R.string.pref_key_rules_order_is_newest_first), newIsNewestFirst).commit()
-                            mSettingsRowAdapter?.replace(SETTINGS_IDX_RULES_ORDER, SettingsCardPresenter.Item(
-                                if (newIsNewestFirst) R.drawable.ic_settings_sort_asc else R.drawable.ic_settings_sort_desc,
-                                if (newIsNewestFirst) getString(R.string.settings_card_sort_oldest) else getString(R.string.settings_card_sort_newest),
-                                SettingsCardPresenter.Item.Action.RULES_ORDER
-                            ))
-                            mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
-                            updateRows()
-                        }
-                        SettingsCardPresenter.Item.Action.BACKGROUND -> {
-                            val showBg = prefs.getBoolean(getString(R.string.pref_key_show_thumbnail_background), false)
-                            val newShowBg = !showBg
-                            prefs.edit().putBoolean(getString(R.string.pref_key_show_thumbnail_background), newShowBg).commit()
-                            startBackgroundTimer()
-                            mSettingsRowAdapter?.replace(SETTINGS_IDX_BACKGROUND, SettingsCardPresenter.Item(
-                                R.drawable.ic_settings_image,
-                                if (newShowBg) getString(R.string.settings_card_bg_off) else getString(R.string.settings_card_bg_on),
-                                SettingsCardPresenter.Item.Action.BACKGROUND
-                            ))
-                        }
-                        SettingsCardPresenter.Item.Action.EMPTY_RULES -> {
-                            val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
-                            val newShowEmptyRules = !showEmptyRules
-                            prefs.edit().putBoolean(getString(R.string.pref_key_show_empty_rules), newShowEmptyRules).commit()
-                            mSettingsRowAdapter?.replace(SETTINGS_IDX_EMPTY_RULES, SettingsCardPresenter.Item(
-                                if (newShowEmptyRules) R.drawable.ic_settings_unfold_less else R.drawable.ic_settings_unfold_more,
-                                if (newShowEmptyRules) getString(R.string.settings_card_rules_hide) else getString(R.string.settings_card_rules_show),
-                                SettingsCardPresenter.Item.Action.EMPTY_RULES
-                            ))
-                            if (newShowEmptyRules) {
-                                updateRows() // 行を追加するだけなので構造変化なし、フォーカス維持
-                            } else {
-                                mMainMenuAdapter.removeEmptyRuleRows() // 0件行だけを個別削除
-                            }
                         }
                     }
                 }
@@ -1123,11 +1102,6 @@ class MainFragment : BrowseSupportFragment() {
         private const val TAG = "MainFragment"
 
         private const val BACKGROUND_UPDATE_DELAY = 300
-
-        // loadRows() で追加する設定カードの順序インデックス
-        private const val SETTINGS_IDX_RULES_ORDER = 3
-        private const val SETTINGS_IDX_BACKGROUND  = 4
-        private const val SETTINGS_IDX_EMPTY_RULES  = 5
     }
 
 

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -886,10 +886,18 @@ class MainFragment : BrowseSupportFragment() {
             else
                 listRow.adapter as ArrayObjectAdapter
 
-            // 既存の行がなければ、新たに作った行を追加する。
-            if(listRow==null){
-                val header = HeaderItem( headerId ,title)
-                addToCategory(category,ListRow(header, listRowAdapter))
+            // 既存の行がなければ追加する。ただし RECORDED_BY_RULES かつ showEmptyRules=false の場合は
+            // API レスポンス確認後に追加する（一時的な空行挿入による mSelectedPosition 増加を防ぐため）。
+            val showEmptyRulesPref = PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+            val addedUpfront = if (listRow == null) {
+                val deferred = category == Category.RECORDED_BY_RULES && !showEmptyRulesPref
+                if (!deferred) {
+                    addToCategory(category, ListRow(HeaderItem(headerId, title), listRowAdapter))
+                }
+                !deferred
+            } else {
+                true
             }
 
             // すでにロードされている数。
@@ -949,7 +957,17 @@ class MainFragment : BrowseSupportFragment() {
                                 recording = v1Pram.recording))
                         }
 
-                        // 録画0件かつ設定がOFFの場合はルール行を非表示にする
+                        // 遅延追加: API 結果を見てから行を追加 or スキップ
+                        if (!addedUpfront && getListRowByHeaderId(headerId) == null) {
+                            val showEmptyRules = PreferenceManager.getDefaultSharedPreferences(context)
+                                .getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+                            if (getRecordedResponse.total == 0L && !showEmptyRules) {
+                                return@let  // 空ルールは非表示のままスキップ
+                            }
+                            addToCategory(category, ListRow(HeaderItem(headerId, title), listRowAdapter))
+                        }
+
+                        // 録画0件かつ設定がOFFの場合は既存ルール行を非表示にする
                         if (getRecordedResponse.total == 0L && category == Category.RECORDED_BY_RULES) {
                             val showEmptyRules = PreferenceManager.getDefaultSharedPreferences(context)
                                 .getBoolean(getString(R.string.pref_key_show_empty_rules), true)
@@ -1011,7 +1029,17 @@ class MainFragment : BrowseSupportFragment() {
                                 hasOriginalFile = v2Param.hasOriginalFile))
                         }
 
-                        // 録画0件かつ設定がOFFの場合はルール行を非表示にする
+                        // 遅延追加: API 結果を見てから行を追加 or スキップ
+                        if (!addedUpfront && getListRowByHeaderId(headerId) == null) {
+                            val showEmptyRules = PreferenceManager.getDefaultSharedPreferences(context)
+                                .getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+                            if (getRecordedResponse.total == 0 && !showEmptyRules) {
+                                return@let  // 空ルールは非表示のままスキップ
+                            }
+                            addToCategory(category, ListRow(HeaderItem(headerId, title), listRowAdapter))
+                        }
+
+                        // 録画0件かつ設定がOFFの場合は既存ルール行を非表示にする
                         if (getRecordedResponse.total == 0 && category == Category.RECORDED_BY_RULES) {
                             val showEmptyRules = PreferenceManager.getDefaultSharedPreferences(context)
                                 .getBoolean(getString(R.string.pref_key_show_empty_rules), true)

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -61,12 +61,14 @@ class MainFragment : BrowseSupportFragment() {
         when (key) {
             getString(R.string.pref_key_rules_order_is_newest_first) -> {
                 if (isResumed) {
-                    Log.d(TAG, "prefChanged: rules_order → deleteCategory(RECORDED_BY_RULES) before=${mMainMenuAdapter.size()}")
+                    Log.d(TAG, "prefChanged: rules_order → deleteCategory(RECORDED_BY_RULES+SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
                     mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
+                    mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
                     Log.d(TAG, "prefChanged: rules_order → after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
                     updateRows()
                 } else {
-                    Log.d(TAG, "prefChanged: rules_order skipped (not resumed)")
+                    Log.d(TAG, "prefChanged: rules_order skipped (not resumed) → mNeedsReloadHistoryOnResume=true")
+                    mNeedsReloadHistoryOnResume = true
                 }
             }
             getString(R.string.pref_key_show_thumbnail_background) -> {
@@ -151,11 +153,14 @@ class MainFragment : BrowseSupportFragment() {
                 }
             }
             mNeedsReloadHistoryOnResume -> {
-                Log.d(TAG, "onResume: branch=reloadHistory → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
-                mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
-                Log.d(TAG, "onResume: after deleteCategory(SEARCH_HISTORY) adapterSize=${mMainMenuAdapter.size()}")
-                updateRows()
+                Log.d(TAG, "onResume: branch=reloadHistory → deferring to view.post")
                 mNeedsReloadHistoryOnResume = false
+                view?.post {
+                    Log.d(TAG, "onResume: reloadHistory deferred → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
+                    mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
+                    Log.d(TAG, "onResume: reloadHistory deferred → after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
+                    updateRows()
+                }
             }
             else -> {
                 Log.d(TAG, "onResume: branch=else → updateRows")
@@ -386,8 +391,13 @@ class MainFragment : BrowseSupportFragment() {
         )
 
 
+        //ルール・履歴の並び順を表すフラグ。デフォルトfalse。
+        val isNewestFirst = PreferenceManager.getDefaultSharedPreferences(context).getBoolean(getString(R.string.pref_key_rules_order_is_newest_first),false)
+
         //履歴行の追加
-        SearchFragment.getHistory(requireContext()).asReversed().forEachIndexed{ index, it ->
+        val historyList = SearchFragment.getHistory(requireContext())
+        val orderedHistory = if (isNewestFirst) historyList.asReversed() else historyList
+        orderedHistory.forEachIndexed { index, it ->
             mMainMenuAdapter.updateContentsListRowWithCategory(
                 GetRecordedParam(keyword = it),
                 GetRecordedParamV2(keyword = it),
@@ -396,9 +406,6 @@ class MainFragment : BrowseSupportFragment() {
                 index.toLong()
             )
         }
-
-        //ルールの並び順を表すフラグ。デフォルトfalse。
-        val isNewestFirst = PreferenceManager.getDefaultSharedPreferences(context).getBoolean(getString(R.string.pref_key_rules_order_is_newest_first),false)
 
         //次の横の列。録画ルール。録画ルールの数だけ行が増える。
         EpgStation.api?.getRulesList()?.enqueue(object : Callback<List<RuleList>> {

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -60,47 +60,36 @@ class MainFragment : BrowseSupportFragment() {
         Log.d(TAG, "prefChanged key=$key isResumed=$isResumed adapterSize=${mMainMenuAdapter.size()} selectedPos=$selectedPosition")
         when (key) {
             getString(R.string.pref_key_rules_order_is_newest_first) -> {
-                if (isResumed) {
-                    Log.d(TAG, "prefChanged: rules_order → setSelectedPosition(0) before deleteCategory")
-                    setSelectedPosition(0, false)
-                    Log.d(TAG, "prefChanged: rules_order → deleteCategory(RECORDED_BY_RULES+SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
-                    mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
-                    mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
-                    Log.d(TAG, "prefChanged: rules_order → after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
-                    updateRows()
-                } else {
-                    Log.d(TAG, "prefChanged: rules_order skipped (not resumed) → mNeedsReloadHistoryOnResume=true")
-                    mNeedsReloadHistoryOnResume = true
-                }
+                Log.d(TAG, "prefChanged: rules_order → setSelectedPosition(0) before deleteCategory")
+                setSelectedPosition(0, false)
+                Log.d(TAG, "prefChanged: rules_order → deleteCategory(RECORDED_BY_RULES+SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
+                mMainMenuAdapter.deleteCategory(Category.RECORDED_BY_RULES)
+                mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
+                Log.d(TAG, "prefChanged: rules_order → after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
+                updateRows()
             }
             getString(R.string.pref_key_show_thumbnail_background) -> {
                 startBackgroundTimer()
             }
             getString(R.string.pref_key_show_empty_rules) -> {
-                if (isResumed) {
-                    val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
-                    Log.d(TAG, "prefChanged: show_empty_rules=$showEmptyRules adapterSize=${mMainMenuAdapter.size()}")
-                    if (showEmptyRules) updateRows() else mMainMenuAdapter.removeEmptyRuleRows()
-                } else {
-                    Log.d(TAG, "prefChanged: show_empty_rules skipped (not resumed)")
-                }
+                val showEmptyRules = prefs.getBoolean(getString(R.string.pref_key_show_empty_rules), true)
+                Log.d(TAG, "prefChanged: show_empty_rules=$showEmptyRules adapterSize=${mMainMenuAdapter.size()}")
+                setSelectedPosition(0, false)
+                if (showEmptyRules) updateRows() else mMainMenuAdapter.removeEmptyRuleRows()
             }
             getString(R.string.pref_key_num_of_history) -> {
-                Log.d(TAG, "prefChanged: num_of_history → mNeedsReloadHistoryOnResume=true")
-                mNeedsReloadHistoryOnResume = true
+                Log.d(TAG, "prefChanged: num_of_history → setSelectedPosition(0) + deleteCategory(SEARCH_HISTORY)")
+                setSelectedPosition(0, false)
+                mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
+                updateRows()
             }
             "pref_key_search_histories" -> {
-                if (isResumed) {
-                    Log.d(TAG, "prefChanged: search_histories → setSelectedPosition(0) before deleteCategory")
-                    setSelectedPosition(0, false)
-                    Log.d(TAG, "prefChanged: search_histories cleared → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
-                    mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
-                    Log.d(TAG, "prefChanged: search_histories after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
-                    updateRows()
-                } else {
-                    Log.d(TAG, "prefChanged: search_histories (not resumed) → mNeedsReloadHistoryOnResume=true")
-                    mNeedsReloadHistoryOnResume = true
-                }
+                Log.d(TAG, "prefChanged: search_histories → setSelectedPosition(0) before deleteCategory")
+                setSelectedPosition(0, false)
+                Log.d(TAG, "prefChanged: search_histories cleared → deleteCategory(SEARCH_HISTORY) before=${mMainMenuAdapter.size()}")
+                mMainMenuAdapter.deleteCategory(Category.SEARCH_HISTORY)
+                Log.d(TAG, "prefChanged: search_histories after deleteCategory adapterSize=${mMainMenuAdapter.size()}")
+                updateRows()
             }
         }
     }

--- a/app/src/main/java/com/daigorian/epcltvapp/OriginalCardPresenter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/OriginalCardPresenter.kt
@@ -148,7 +148,12 @@ class OriginalCardPresenter() : Presenter() {
             is RecordedProgram -> {
                 // EPGStation Version 1.x.x
                 cardView.titleText = item.name
-                cardView.contentText = "${formatAsJapaneseDateTime(item.startAt)}〜 (${formatDurationMinutes(item.startAt, item.endAt)})\n${item.description ?: ""}"
+                val channelNameV1 = EpgStation.channelMap[item.channelId] ?: ""
+                cardView.contentText = buildString {
+                    if (channelNameV1.isNotEmpty()) { append(channelNameV1); append("\n") }
+                    append("${formatAsJapaneseDateTime(item.startAt)}〜 (${formatDurationMinutes(item.startAt, item.endAt)})")
+                    if (!item.description.isNullOrEmpty()) { append("\n"); append(item.description) }
+                }
                 val thumbnailURL = EpgStation.getThumbnailURL(item.id.toString())
 
                 //Glideでイメージを取得する際にBasic認証が必要な場合はヘッダを付与してやる
@@ -168,7 +173,12 @@ class OriginalCardPresenter() : Presenter() {
             is RecordedItem -> {
                 // EPGStation Version 2.x.x
                 cardView.titleText = item.name
-                cardView.contentText = "${formatAsJapaneseDateTime(item.startAt)}〜 (${formatDurationMinutes(item.startAt, item.endAt)})\n${item.description ?: ""}"
+                val channelNameV2 = item.channelId?.let { EpgStationV2.channelMap[it] } ?: ""
+                cardView.contentText = buildString {
+                    if (channelNameV2.isNotEmpty()) { append(channelNameV2); append("\n") }
+                    append("${formatAsJapaneseDateTime(item.startAt)}〜 (${formatDurationMinutes(item.startAt, item.endAt)})")
+                    if (!item.description.isNullOrEmpty()) { append("\n"); append(item.description) }
+                }
                 //サムネのURLから画像をロードする。失敗した場合、録画中なら録画中アイコンを出す。そうでなければNO IMAGEアイコン。
 
                 val thumbnailURL = if(!item.thumbnails.isNullOrEmpty()){

--- a/app/src/main/java/com/daigorian/epcltvapp/ProgramInfoDialogFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/ProgramInfoDialogFragment.kt
@@ -1,0 +1,81 @@
+package com.daigorian.epcltvapp
+
+import android.os.Bundle
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.fragment.app.DialogFragment
+
+class ProgramInfoDialogFragment : DialogFragment() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NO_TITLE, R.style.ProgramInfoDialogTheme)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return inflater.inflate(R.layout.dialog_program_info, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewById<TextView>(R.id.program_info_title).text = requireArguments().getString(ARG_TITLE)
+
+        val bodyTextView = view.findViewById<TextView>(R.id.program_info_body)
+        bodyTextView.text = requireArguments().getString(ARG_BODY)
+
+        val scrollView = view.findViewById<ScrollView>(R.id.program_info_scroll)
+        scrollView.requestFocus()
+        scrollView.setOnKeyListener { _, keyCode, event ->
+            if (event.action == KeyEvent.ACTION_DOWN) {
+                val scrollAmount = bodyTextView.lineHeight * 3
+                when (keyCode) {
+                    KeyEvent.KEYCODE_DPAD_DOWN -> {
+                        if (scrollView.canScrollVertically(1)) {
+                            scrollView.smoothScrollBy(0, scrollAmount)
+                            true
+                        } else false
+                    }
+                    KeyEvent.KEYCODE_DPAD_UP -> {
+                        if (scrollView.canScrollVertically(-1)) {
+                            scrollView.smoothScrollBy(0, -scrollAmount)
+                            true
+                        } else false
+                    }
+                    else -> false
+                }
+            } else false
+        }
+
+        view.findViewById<Button>(R.id.program_info_close).setOnClickListener {
+            dismiss()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val width = (resources.displayMetrics.widthPixels * 0.7).toInt()
+        val height = (resources.displayMetrics.heightPixels * 0.8).toInt()
+        dialog?.window?.setLayout(width, height)
+    }
+
+    companion object {
+        const val TAG = "ProgramInfoDialog"
+        private const val ARG_TITLE = "title"
+        private const val ARG_BODY = "body"
+
+        fun newInstance(title: String, body: String): ProgramInfoDialogFragment {
+            return ProgramInfoDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_TITLE, title)
+                    putString(ARG_BODY, body)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/daigorian/epcltvapp/SearchFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SearchFragment.kt
@@ -34,6 +34,8 @@ class SearchFragment : SearchSupportFragment() , SearchSupportFragment.SearchRes
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val historyOnCreate = getHistory(requireContext())
+        Log.i(TAG, "onCreate historyCount=${historyOnCreate.size} history=${historyOnCreate}")
         mCardPresenter.objAdapter = mRowsAdapter
         setSearchResultProvider(this)
         setOnItemViewClickedListener(ItemViewClickedListener())
@@ -53,10 +55,20 @@ class SearchFragment : SearchSupportFragment() , SearchSupportFragment.SearchRes
 
         }
         mRowsAdapter.clear()
-        getHistory(requireContext()).forEach { queryHistory ->
+        historyOnCreate.forEach { queryHistory ->
             addResultRow(query = queryHistory, recodeHistory=false,showErrorToast = false)
         }
 
+    }
+
+    override fun onResume() {
+        super.onResume()
+        Log.i(TAG, "onResume rowsAdapterSize=${mRowsAdapter.size()}")
+    }
+
+    override fun onPause() {
+        super.onPause()
+        Log.d(TAG, "onPause rowsAdapterSize=${mRowsAdapter.size()}")
     }
 
     override fun onQueryTextChange(newQuery: String?): Boolean {
@@ -64,8 +76,7 @@ class SearchFragment : SearchSupportFragment() , SearchSupportFragment.SearchRes
     }
 
     override fun onQueryTextSubmit(query: String): Boolean {
-
-
+        Log.i(TAG, "onQueryTextSubmit query='$query'")
         if (!TextUtils.isEmpty(query)) {
             addResultRow(query)
         }
@@ -347,6 +358,7 @@ class SearchFragment : SearchSupportFragment() , SearchSupportFragment.SearchRes
     }
 
     private fun addHistory(keyword:String){
+        Log.d(TAG, "addHistory keyword='$keyword'")
         val pref = PreferenceManager.getDefaultSharedPreferences(context)
         val edit = pref.edit()
         var histories = pref.getString("pref_key_search_histories", "")

--- a/app/src/main/java/com/daigorian/epcltvapp/SettingsCardPresenter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SettingsCardPresenter.kt
@@ -16,7 +16,7 @@ class SettingsCardPresenter : Presenter() {
         val action: Action
     ) {
         enum class Action {
-            CONNECTION, PLAYER, RELOAD, RULES_ORDER, BACKGROUND, EMPTY_RULES
+            CONNECTION, PLAYER, DISPLAY, RELOAD
         }
     }
 

--- a/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
@@ -111,6 +111,16 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
                 enableCustomBaseUrlUI(newValue as Boolean)
                 true
             }
+
+            preferenceScreen.findPreference<Preference>(getText(R.string.pref_key_clear_history))
+                ?.setOnPreferenceClickListener {
+                    PreferenceManager.getDefaultSharedPreferences(requireContext())
+                        .edit()
+                        .putString("pref_key_search_histories", "")
+                        .apply()
+                    Toast.makeText(activity, getString(R.string.history_cleared), Toast.LENGTH_SHORT).show()
+                    true
+                }
         }
 
         private fun enableCustomBaseUrlUI(boolean: Boolean) {

--- a/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
@@ -2,6 +2,7 @@ package com.daigorian.epcltvapp
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.leanback.preference.LeanbackPreferenceFragment
 import androidx.leanback.preference.LeanbackSettingsFragment
@@ -15,6 +16,7 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
         const val ARG_START_SCREEN = "start_screen"
         private const val PREFERENCE_RESOURCE_ID = "preferenceResource"
         private const val PREFERENCE_ROOT = "root"
+        private const val TAG = "SettingsFragment"
 
         private const val IP_REGEX_PATTERN = """^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"""
         private const val PORT_REGEX_PATTERN = """^([1-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"""
@@ -40,6 +42,7 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
 
     override fun onPreferenceStartInitialScreen() {
         val startScreen = arguments?.getString(ARG_START_SCREEN)
+        Log.i(TAG, "onPreferenceStartInitialScreen startScreen=$startScreen")
         mPreferenceFragment = buildPreferenceFragment(R.xml.preferences, startScreen)
         startPreferenceFragment(mPreferenceFragment!!)
     }
@@ -77,6 +80,7 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             val root = arguments.getString(PREFERENCE_ROOT, null)
             val prefResId = arguments.getInt(PREFERENCE_RESOURCE_ID)
+            Log.i(TAG, "PrefFragment.onCreatePreferences root=$root")
             if (root == null) {
                 addPreferencesFromResource(prefResId)
             } else {
@@ -87,6 +91,7 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
             ipAddressPref?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, value ->
                 val regex = Regex(pattern = IP_REGEX_PATTERN)
                 if (value.toString().matches(regex)) {
+                    Log.i(TAG, "pref ip_addr changed to '$value'")
                     true
                 } else {
                     Toast.makeText(activity, getString(R.string.not_a_valid_ipv4_addr, value.toString()), Toast.LENGTH_LONG).show()
@@ -98,6 +103,7 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
             portNumPref?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, value ->
                 val regex = Regex(pattern = PORT_REGEX_PATTERN)
                 if (value.toString().matches(regex)) {
+                    Log.i(TAG, "pref port_num changed to '$value'")
                     true
                 } else {
                     Toast.makeText(activity, getString(R.string.not_a_valid_port_num, value.toString()), Toast.LENGTH_LONG).show()
@@ -108,12 +114,14 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
             val useCustomBaseUrlPref = preferenceScreen.findPreference(getText(R.string.pref_key_use_custom_base_url)) as SwitchPreference?
             useCustomBaseUrlPref?.let { enableCustomBaseUrlUI(it.isChecked) }
             useCustomBaseUrlPref?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+                Log.i(TAG, "pref use_custom_base_url changed to $newValue")
                 enableCustomBaseUrlUI(newValue as Boolean)
                 true
             }
 
             preferenceScreen.findPreference<Preference>(getText(R.string.pref_key_clear_history))
                 ?.setOnPreferenceClickListener {
+                    Log.i(TAG, "pref clear_history clicked")
                     PreferenceManager.getDefaultSharedPreferences(activity!!)
                         .edit()
                         .putString("pref_key_search_histories", "")

--- a/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
@@ -114,7 +114,7 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
 
             preferenceScreen.findPreference<Preference>(getText(R.string.pref_key_clear_history))
                 ?.setOnPreferenceClickListener {
-                    PreferenceManager.getDefaultSharedPreferences(requireContext())
+                    PreferenceManager.getDefaultSharedPreferences(activity!!)
                         .edit()
                         .putString("pref_key_search_histories", "")
                         .apply()

--- a/app/src/main/java/com/daigorian/epcltvapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VideoDetailsFragment.kt
@@ -31,6 +31,9 @@ import com.daigorian.epcltvapp.epgstationv2caller.Records
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import java.text.DateFormat
+import java.util.Date
+import java.util.TimeZone
 import kotlin.math.roundToInt
 
 /**
@@ -263,6 +266,8 @@ class VideoDetailsFragment : DetailsSupportFragment() {
 
 
 
+        actionAdapter.add(Action(ACTION_SHOW_DESCRIPTION, getString(R.string.program_info)))
+
         row.actionsAdapter = actionAdapter
 
         mAdapter.add(row)
@@ -284,6 +289,52 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         detailsPresenter.isParticipatingEntranceTransition = true
 
         detailsPresenter.onActionClickedListener = OnActionClickedListener { action ->
+
+            if (action.id == ACTION_SHOW_DESCRIPTION) {
+                val jst = TimeZone.getTimeZone("Asia/Tokyo")
+                val dfDateAndTime = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.SHORT).also { it.timeZone = jst }
+                val dfTime = DateFormat.getTimeInstance(DateFormat.SHORT).also { it.timeZone = jst }
+                val (programName, bodyText) = when {
+                    mSelectedRecordedProgram != null -> {
+                        val it = mSelectedRecordedProgram!!
+                        val channelName = EpgStation.channelMap[it.channelId] ?: ""
+                        val genreText = AribGenre.getGenreText(it.genre1, null)
+                        val recTimeInfo = getString(R.string.start_end_duration,
+                            dfDateAndTime.format(Date(it.startAt)),
+                            dfTime.format(Date(it.endAt)),
+                            (it.endAt - it.startAt) / 60 / 1000)
+                        val body = buildString {
+                            if (channelName.isNotEmpty()) { append(channelName); append("\n") }
+                            if (genreText.isNotEmpty()) { append(genreText); append("\n") }
+                            append(recTimeInfo)
+                            if (!it.description.isNullOrEmpty()) { append("\n\n"); append(it.description) }
+                            if (!it.extended.isNullOrEmpty()) { append("\n"); append(it.extended) }
+                        }
+                        Pair(it.name, body)
+                    }
+                    mSelectedRecordedItem != null -> {
+                        val it = mSelectedRecordedItem!!
+                        val channelName = it.channelId?.let { id -> EpgStationV2.channelMap[id] } ?: ""
+                        val genreText = AribGenre.getGenreText(it.genre1, it.subGenre1)
+                        val recTimeInfo = getString(R.string.start_end_duration,
+                            dfDateAndTime.format(Date(it.startAt)),
+                            dfTime.format(Date(it.endAt)),
+                            (it.endAt - it.startAt) / 60 / 1000)
+                        val body = buildString {
+                            if (channelName.isNotEmpty()) { append(channelName); append("\n") }
+                            if (genreText.isNotEmpty()) { append(genreText); append("\n") }
+                            append(recTimeInfo)
+                            if (!it.description.isNullOrEmpty()) { append("\n\n"); append(it.description) }
+                            if (!it.extended.isNullOrEmpty()) { append("\n"); append(it.extended) }
+                        }
+                        Pair(it.name, body)
+                    }
+                    else -> return@OnActionClickedListener
+                }
+                ProgramInfoDialogFragment.newInstance(programName, bodyText)
+                    .show(childFragmentManager, ProgramInfoDialogFragment.TAG)
+                return@OnActionClickedListener
+            }
 
             val playerPkgName = PreferenceManager.getDefaultSharedPreferences(requireContext()).getString(getString(R.string.pref_key_player),"")
             if( playerPkgName == getString(R.string.pref_options_movie_player_val_INTERNAL)) {
@@ -537,6 +588,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         private const val TAG = "VideoDetailsFragment"
 
         internal const val ACTION_WATCH_ORIGINAL_TS = 0L
+        internal const val ACTION_SHOW_DESCRIPTION = -1L
 
         private const val DETAIL_THUMB_WIDTH = 274
         private const val DETAIL_THUMB_HEIGHT = 274

--- a/app/src/main/java/com/daigorian/epcltvapp/epgstationcaller/ChannelItemV1.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/epgstationcaller/ChannelItemV1.kt
@@ -1,0 +1,6 @@
+package com.daigorian.epcltvapp.epgstationcaller
+
+data class ChannelItemV1(
+    val id: Long = 0,
+    val name: String = ""
+)

--- a/app/src/main/java/com/daigorian/epcltvapp/epgstationcaller/EpgStation.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/epgstationcaller/EpgStation.kt
@@ -9,6 +9,7 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import retrofit2.Call
+import retrofit2.Callback
 import retrofit2.Retrofit.Builder
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.DELETE
@@ -42,6 +43,9 @@ object EpgStation {
 
         @GET("rules/list")
         fun getRulesList(): Call<List<RuleList>>
+
+        @GET("channels")
+        fun getChannels(): Call<List<ChannelItemV1>>
     }
 
     private var baseUrl:String = "http://192.168.0.0:8888/api/"
@@ -54,8 +58,19 @@ object EpgStation {
 
 
     var api: ApiInterface? = null
-
     var authForGlide : LazyHeaders? = null
+    var channelMap: Map<Long, String> = emptyMap()
+
+    fun fetchChannels() {
+        api?.getChannels()?.enqueue(object : Callback<List<ChannelItemV1>> {
+            override fun onResponse(call: Call<List<ChannelItemV1>>, response: retrofit2.Response<List<ChannelItemV1>>) {
+                response.body()?.let { list ->
+                    channelMap = list.associate { item -> item.id to item.name }
+                }
+            }
+            override fun onFailure(call: Call<List<ChannelItemV1>>, t: Throwable) {}
+        })
+    }
 
     fun initAPI(_baseUrl:String){
         baseUrl = _baseUrl

--- a/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/ChannelItem.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/ChannelItem.kt
@@ -1,0 +1,7 @@
+package com.daigorian.epcltvapp.epgstationv2caller
+
+data class ChannelItem(
+    val id: Long = 0,
+    val name: String = "",
+    val halfWidthName: String = ""
+)

--- a/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/EpgStationV2.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/EpgStationV2.kt
@@ -7,6 +7,7 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import retrofit2.Call
+import retrofit2.Callback
 import retrofit2.Retrofit.Builder
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.*
@@ -52,6 +53,9 @@ object EpgStationV2 {
         @GET("version")
         fun getVersion(
         ): Call<Version>
+
+        @GET("channels")
+        fun getChannels(): Call<List<ChannelItem>>
     }
 
 
@@ -68,6 +72,18 @@ object EpgStationV2 {
 
     var api: ApiInterface? = null
     var authForGlide : LazyHeaders? = null
+    var channelMap: Map<Long, String> = emptyMap()
+
+    fun fetchChannels() {
+        api?.getChannels()?.enqueue(object : Callback<List<ChannelItem>> {
+            override fun onResponse(call: Call<List<ChannelItem>>, response: retrofit2.Response<List<ChannelItem>>) {
+                response.body()?.let { list ->
+                    channelMap = list.associate { item -> item.id to item.halfWidthName.ifEmpty { item.name } }
+                }
+            }
+            override fun onFailure(call: Call<List<ChannelItem>>, t: Throwable) {}
+        })
+    }
 
     fun initAPI(_baseUrl:String){
         baseUrl = _baseUrl

--- a/app/src/main/res/layout/dialog_program_info.xml
+++ b/app/src/main/res/layout/dialog_program_info.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="32dp"
+    android:background="@color/default_background">
+
+    <TextView
+        android:id="@+id/program_info_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/white"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:paddingBottom="12dp"
+        android:focusable="false" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#40FFFFFF"
+        android:layout_marginBottom="12dp" />
+
+    <ScrollView
+        android:id="@+id/program_info_scroll"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:focusable="true"
+        android:focusableInTouchMode="false"
+        android:scrollbars="vertical"
+        android:nextFocusDown="@id/program_info_close">
+
+        <TextView
+            android:id="@+id/program_info_body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:lineSpacingMultiplier="1.4"
+            android:focusable="false" />
+
+    </ScrollView>
+
+    <Button
+        android:id="@+id/program_info_close"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:layout_marginTop="12dp"
+        android:text="@string/close"
+        android:focusable="true"
+        android:nextFocusUp="@id/program_info_scroll" />
+
+</LinearLayout>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -68,5 +68,7 @@
     <string name="cancel">キャンセル</string>
     <string name="no_subtitle">字幕なし</string>
     <string name="start_end_duration">%1$s ～ %2$s (%3$d分)</string>
+    <string name="program_info">番組情報</string>
+    <string name="close">閉じる</string>
 
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -26,7 +26,7 @@
     <string name="now_on_recording">録画中</string>
     <string name="reload">録画の再読み込み</string>
     <string name="programs_not_found">%1$s を含む録画は見つかりませんでした</string>
-    <string name="num_of_history">検索履歴の数</string>
+    <string name="num_of_history">検索履歴の表示件数</string>
     <string name="pref_options_num_of_history_label_0">0</string>
     <string name="pref_options_num_of_history_label_1">1</string>
     <string name="pref_options_num_of_history_label_2">2</string>
@@ -56,7 +56,6 @@
     <string name="pref_category_history_display">履歴表示設定</string>
     <string name="show_thumbnail_background">サムネイル背景表示</string>
     <string name="show_empty_rules">0件ルールの表示</string>
-    <string name="num_of_history">検索履歴の表示件数</string>
     <string name="clear_history">検索履歴のクリア</string>
     <string name="history_cleared">検索履歴をクリアしました</string>
 

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -38,8 +38,8 @@
     <string name="by_rec_rules">録画ルール</string>
     <string name="search_history">検索履歴</string>
     <string name="program_name">番組名</string>
-    <string name="set_newest_rule_first">録画ルールの新しい順表示</string>
-    <string name="set_oldest_rule_first">録画ルールの古い順表示</string>
+    <string name="set_newest_rule_first">ルール/履歴の新しい順表示</string>
+    <string name="set_oldest_rule_first">ルール/履歴の古い順表示</string>
 
     <!-- Settings card labels -->
     <string name="settings_connection">接続設定</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -38,24 +38,28 @@
     <string name="by_rec_rules">録画ルール</string>
     <string name="search_history">検索履歴</string>
     <string name="program_name">番組名</string>
-    <string name="set_newest_rule_first">録画ルールを新しい順に並べ替え</string>
-    <string name="set_oldest_rule_first">録画ルールを古い順に並べ替え</string>
+    <string name="set_newest_rule_first">録画ルールの新しい順表示</string>
+    <string name="set_oldest_rule_first">録画ルールの古い順表示</string>
 
     <!-- Settings card labels -->
     <string name="settings_connection">接続設定</string>
     <string name="settings_player">再生設定</string>
-    <string name="settings_card_sort_newest">ルール/履歴 新しい順</string>
-    <string name="settings_card_sort_oldest">ルール/履歴 古い順</string>
-    <string name="settings_card_bg_on">背景表示オン</string>
-    <string name="settings_card_bg_off">背景表示オフ</string>
-    <string name="settings_card_rules_show">0件ルール表示</string>
-    <string name="settings_card_rules_hide">0件ルール非表示</string>
+    <string name="settings_display">表示設定</string>
 
     <!-- Settings sub-screen titles -->
     <string name="settings_connection_title">接続設定</string>
     <string name="settings_player_title">再生設定</string>
-    <string name="show_thumbnail_background">番組選択画面でサムネイルを背景表示する</string>
-    <string name="show_empty_rules">録画済み0件の録画ルールを表示する</string>
+
+    <!-- Display settings -->
+    <string name="pref_category_general_display">全体設定</string>
+    <string name="pref_category_rules_display">ルール表示設定</string>
+    <string name="pref_category_history_display">履歴表示設定</string>
+    <string name="show_thumbnail_background">サムネイル背景表示</string>
+    <string name="show_empty_rules">0件ルールの表示</string>
+    <string name="num_of_history">検索履歴の表示件数</string>
+    <string name="clear_history">検索履歴のクリア</string>
+    <string name="history_cleared">検索履歴をクリアしました</string>
+
     <string name="use_custom_base_url">API Base URLを編集する</string>
     <string name="customize_base_url">API Base URL</string>
     <string name="do_you_want_to_delete">%1$s を削除しますか</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,8 +122,8 @@
     <string name="pref_category_history_display">History Display</string>
 
     <string name="pref_key_rules_order_is_newest_first"   translatable="false">KEY_RULES_ORDER_IS_NEWEST_FIRST</string>
-    <string name="set_newest_rule_first">Newest-first rule display</string>
-    <string name="set_oldest_rule_first">Oldest-first rule display</string>
+    <string name="set_newest_rule_first">Newest-first rule &amp; history display</string>
+    <string name="set_oldest_rule_first">Oldest-first rule &amp; history display</string>
 
     <string name="pref_key_show_empty_rules" translatable="false">KEY_SHOW_EMPTY_RULES</string>
     <string name="show_empty_rules">Empty rule display</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,6 @@
     <string name="port_number_of_epgstation">Port Number of EPGStation</string>
     <string name="version_of_epgstation">Version of EPGStation</string>
     <string name="reload">Reload</string>
-    <string name="num_of_history">Number of search histories</string>
 
 
     <!-- Error messages -->
@@ -118,23 +117,25 @@
     <string name="settings_player_title">Playback Settings</string>
 
     <!-- Display settings preference categories -->
+    <string name="pref_category_general_display">General</string>
     <string name="pref_category_rules_display">Rule Display</string>
     <string name="pref_category_history_display">History Display</string>
 
     <string name="pref_key_rules_order_is_newest_first"   translatable="false">KEY_RULES_ORDER_IS_NEWEST_FIRST</string>
-    <string name="set_newest_rule_first">Newest rule first</string>
-    <string name="set_oldest_rule_first">Oldest rule first</string>
+    <string name="set_newest_rule_first">Newest-first rule display</string>
+    <string name="set_oldest_rule_first">Oldest-first rule display</string>
 
     <string name="pref_key_show_empty_rules" translatable="false">KEY_SHOW_EMPTY_RULES</string>
-    <string name="show_empty_rules">Show recording rules with no recordings</string>
+    <string name="show_empty_rules">Empty rule display</string>
 
     <string name="pref_key_show_thumbnail_background" translatable="false">KEY_SHOW_THUMBNAIL_BACKGROUND</string>
-    <string name="show_thumbnail_background">番組選択画面でサムネイルを背景表示する</string>
+    <string name="show_thumbnail_background">Thumbnail background</string>
 
     <!-- History display -->
     <string name="pref_key_clear_history" translatable="false">pref_key_clear_history_action</string>
-    <string name="clear_history">Clear search history</string>
+    <string name="clear_history">Search history clear</string>
     <string name="history_cleared">Search history cleared</string>
+    <string name="num_of_history">Search history count</string>
 
     <string name="pref_key_use_custom_base_url"   translatable="false">KEY_RULES_USE_CUSTOM_BASE_URL</string>
     <string name="use_custom_base_url">Use a custom EPGStation API base URL</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,18 +108,18 @@
     <!-- Settings screen sub-screen keys -->
     <string name="pref_key_screen_connection" translatable="false">pref_screen_connection</string>
     <string name="pref_key_screen_player"     translatable="false">pref_screen_player</string>
+    <string name="pref_key_screen_display"    translatable="false">pref_screen_display</string>
 
     <!-- Settings card labels -->
     <string name="settings_connection">Connection</string>
     <string name="settings_player">Playback Settings</string>
+    <string name="settings_display">Display Settings</string>
     <string name="settings_connection_title">Connection Settings</string>
     <string name="settings_player_title">Playback Settings</string>
-    <string name="settings_card_sort_newest">Rules: Newest</string>
-    <string name="settings_card_sort_oldest">Rules: Oldest</string>
-    <string name="settings_card_bg_on">Background ON</string>
-    <string name="settings_card_bg_off">Background OFF</string>
-    <string name="settings_card_rules_show">0-rec Rules: ON</string>
-    <string name="settings_card_rules_hide">0-rec Rules: OFF</string>
+
+    <!-- Display settings preference categories -->
+    <string name="pref_category_rules_display">Rule Display</string>
+    <string name="pref_category_history_display">History Display</string>
 
     <string name="pref_key_rules_order_is_newest_first"   translatable="false">KEY_RULES_ORDER_IS_NEWEST_FIRST</string>
     <string name="set_newest_rule_first">Newest rule first</string>
@@ -130,6 +130,11 @@
 
     <string name="pref_key_show_thumbnail_background" translatable="false">KEY_SHOW_THUMBNAIL_BACKGROUND</string>
     <string name="show_thumbnail_background">番組選択画面でサムネイルを背景表示する</string>
+
+    <!-- History display -->
+    <string name="pref_key_clear_history" translatable="false">pref_key_clear_history_action</string>
+    <string name="clear_history">Clear search history</string>
+    <string name="history_cleared">Search history cleared</string>
 
     <string name="pref_key_use_custom_base_url"   translatable="false">KEY_RULES_USE_CUSTOM_BASE_URL</string>
     <string name="use_custom_base_url">Use a custom EPGStation API base URL</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,8 @@
     <string name="no_subtitle">No subtitle</string>
     <string name="subtitle_off">Subtitle OFF</string>
     <string name="start_end_duration">%1$s - %2$s (%3$d min.)</string>
+    <string name="program_info">Program Info</string>
+    <string name="close">Close</string>
 
 
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,6 +12,11 @@
     </style>
 
 
+    <style name="ProgramInfoDialogTheme" parent="@style/Theme.AppCompat.Dialog">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+
     <style name="CustomizedSearch" parent="@style/Theme.Epcltvapp">
         <item name="android:windowBackground">@color/background_epgstation</item>
     </style>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -57,17 +57,22 @@
         app:title="@string/settings_display">
 
         <PreferenceCategory
+            app:title="@string/pref_category_general_display">
+
+            <SwitchPreference
+                app:key=         "@string/pref_key_show_thumbnail_background"
+                app:defaultValue="false"
+                app:title=       "@string/show_thumbnail_background" />
+
+        </PreferenceCategory>
+
+        <PreferenceCategory
             app:title="@string/pref_category_rules_display">
 
             <SwitchPreference
                 app:key=         "@string/pref_key_rules_order_is_newest_first"
                 app:defaultValue="false"
                 app:title=       "@string/set_newest_rule_first" />
-
-            <SwitchPreference
-                app:key=         "@string/pref_key_show_thumbnail_background"
-                app:defaultValue="false"
-                app:title=       "@string/show_thumbnail_background" />
 
             <SwitchPreference
                 app:key=         "@string/pref_key_show_empty_rules"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -50,14 +50,49 @@
             app:useSimpleSummaryProvider="true"
             />
 
-        <ListPreference
-            app:key=         "@string/pref_key_num_of_history"
-            app:defaultValue="@string/pref_val_num_of_history_default"
-            app:title=       "@string/num_of_history"
-            app:entries=     "@array/pref_options_num_of_history_label"
-            app:entryValues= "@array/pref_options_num_of_history_val"
-            app:useSimpleSummaryProvider="true"
-            />
+    </PreferenceScreen>
+
+    <PreferenceScreen
+        app:key="@string/pref_key_screen_display"
+        app:title="@string/settings_display">
+
+        <PreferenceCategory
+            app:title="@string/pref_category_rules_display">
+
+            <SwitchPreference
+                app:key=         "@string/pref_key_rules_order_is_newest_first"
+                app:defaultValue="false"
+                app:title=       "@string/set_newest_rule_first" />
+
+            <SwitchPreference
+                app:key=         "@string/pref_key_show_thumbnail_background"
+                app:defaultValue="false"
+                app:title=       "@string/show_thumbnail_background" />
+
+            <SwitchPreference
+                app:key=         "@string/pref_key_show_empty_rules"
+                app:defaultValue="true"
+                app:title=       "@string/show_empty_rules" />
+
+        </PreferenceCategory>
+
+        <PreferenceCategory
+            app:title="@string/pref_category_history_display">
+
+            <ListPreference
+                app:key=         "@string/pref_key_num_of_history"
+                app:defaultValue="@string/pref_val_num_of_history_default"
+                app:title=       "@string/num_of_history"
+                app:entries=     "@array/pref_options_num_of_history_label"
+                app:entryValues= "@array/pref_options_num_of_history_val"
+                app:useSimpleSummaryProvider="true"
+                />
+
+            <Preference
+                app:key=  "@string/pref_key_clear_history"
+                app:title="@string/clear_history" />
+
+        </PreferenceCategory>
 
     </PreferenceScreen>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -64,15 +64,15 @@
                 app:defaultValue="false"
                 app:title=       "@string/show_thumbnail_background" />
 
-        </PreferenceCategory>
-
-        <PreferenceCategory
-            app:title="@string/pref_category_rules_display">
-
             <SwitchPreference
                 app:key=         "@string/pref_key_rules_order_is_newest_first"
                 app:defaultValue="false"
                 app:title=       "@string/set_newest_rule_first" />
+
+        </PreferenceCategory>
+
+        <PreferenceCategory
+            app:title="@string/pref_category_rules_display">
 
             <SwitchPreference
                 app:key=         "@string/pref_key_show_empty_rules"


### PR DESCRIPTION
## Summary

- 詳細画面（VideoDetailsFragment）に「番組情報」ボタンを追加。D-padでスクロール可能なダイアログで番組説明全文を表示
- 時刻表示を端末ロケール問わず日本時間（JST / Asia/Tokyo）に固定
- カード一覧・詳細画面にチャンネル名を表示（EPGStation V1/V2 両対応）
- 番組情報ダイアログにチャンネル名・ジャンル/サブジャンルを表示
- ARIBジャンルテーブルをEPGStation（`client/src/lib/event.ts`）準拠に修正

## 変更ファイル

- `AribGenre.kt` (新規): EPGStation準拠のジャンル/サブジャンルテーブル
- `ProgramInfoDialogFragment.kt` (新規): スクロール可能な番組情報ダイアログ
- `ChannelItem.kt` / `ChannelItemV1.kt` (新規): チャンネルAPIレスポンスの data class
- `dialog_program_info.xml` (新規): ダイアログレイアウト
- `EpgStationV2.kt` / `EpgStation.kt`: `getChannels()` API・`channelMap`・`fetchChannels()` を追加
- `MainFragment.kt`: 起動時に `fetchChannels()` を呼び出しチャンネルマップを初期化
- `VideoDetailsFragment.kt`: 番組情報ボタン追加・JST時刻表示
- `OriginalCardPresenter.kt`: カードのcontentTextにチャンネル名を追加
- `DetailsDescriptionPresenter.kt`: 詳細画面のbodyにチャンネル名+時刻を同行表示・JST時刻表示

## Test plan

- [x] カード一覧でチャンネル名が時刻の前に表示されること
- [x] 詳細画面でチャンネル名と時刻が同じ行に表示されること
- [x] 詳細画面で「番組情報」ボタンが表示され、押すとダイアログが開くこと
- [x] ダイアログ内でD-pad DOWN/UPでスクロールできること
- [x] ダイアログ内のチャンネル名・ジャンル表示が正しいこと（例: テレ東 / アニメ・特撮 / 国内アニメ）
- [x] 時刻が日本時間で表示されること
- [x] EPGStation V1 / V2 両方で動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)