### PR TITLE
fix: 内蔵プレーヤーでエンコード済み動画がフルスクリーン表示されない問題を修正 (#22)

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
@@ -149,6 +149,7 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
                 if (w > 0 && h > 0) {
                     Log.d(TAG, "VLCVideoLayout layout changed: ${w}x${h}, calling setWindowSize")
                     vlcPlayer.vlcVout.setWindowSize(w, h)
+                    vlcPlayer.scale = 0.0f
                 }
             }
             mInitialized = true

--- a/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
@@ -341,9 +341,7 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
                 Event.Vout -> {
                     Log.d(TAG, "libvlc Event.Vout. Vout count: " + event.voutCount)
                     callback.onBufferingStateChanged(this@VlcPlayerAdapter, false)
-                    if (event.voutCount > 0) {
-                        vlcPlayer.aspectRatio = "16:9"
-                    }
+
                 }
                 Event.ESAdded -> {
                     // A track was added

--- a/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
@@ -141,6 +141,16 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
         }
         if(vlcVideoLayout != null){
             vlcPlayer.attachViews(vlcVideoLayout,null, true, false)
+            // attachViews 時点では VLCVideoLayout が未レイアウトで windowSize=0 の場合がある。
+            // レイアウト確定後に明示的に setWindowSize を呼ぶことで VLC のスケーリングを正しく機能させる。
+            vlcVideoLayout.addOnLayoutChangeListener { _, left, top, right, bottom, _, _, _, _ ->
+                val w = right - left
+                val h = bottom - top
+                if (w > 0 && h > 0) {
+                    Log.d(TAG, "VLCVideoLayout layout changed: ${w}x${h}, calling setWindowSize")
+                    vlcPlayer.vlcVout.setWindowSize(w, h)
+                }
+            }
             mInitialized = true
         }else{
             mInitialized = false

--- a/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
@@ -341,7 +341,9 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
                 Event.Vout -> {
                     Log.d(TAG, "libvlc Event.Vout. Vout count: " + event.voutCount)
                     callback.onBufferingStateChanged(this@VlcPlayerAdapter, false)
-
+                    if (event.voutCount > 0) {
+                        vlcPlayer.aspectRatio = "16:9"
+                    }
                 }
                 Event.ESAdded -> {
                     // A track was added

--- a/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
@@ -341,7 +341,9 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
                 Event.Vout -> {
                     Log.d(TAG, "libvlc Event.Vout. Vout count: " + event.voutCount)
                     callback.onBufferingStateChanged(this@VlcPlayerAdapter, false)
-
+                    if (event.voutCount > 0) {
+                        vlcPlayer.scale = 0.0f
+                    }
                 }
                 Event.ESAdded -> {
                     // A track was added


### PR DESCRIPTION
Closes #22

## 概要

内蔵プレーヤー（libVLC）でエンコード済み 720p 動画を再生すると、フルスクリーンにならず黒帯が表示される問題を修正する。

## 原因

`setVLCVideoLayout()` は `onCreateView` 内で呼ばれるため、`attachViews` 実行時点では `VLCVideoLayout` がまだレイアウトされておらず、VLC へ渡るウィンドウサイズが 0×0 になっていた。

libVLC 4.0 EAP では `VLCVideoLayout.onSizeChanged` → `setWindowSize` の自動連携が正しく機能せず、VLC がネイティブ解像度（例: 1280×720）のまま描画を続けていた。

## 修正内容

- `addOnLayoutChangeListener` でレイアウト確定後に `vlcVout.setWindowSize(w, h)` を明示呼び出し
- 同タイミングで `scale = 0.0f` を設定して VLC にスケーリングの再計算を促す
- `Event.Vout` でも `scale = 0.0f` を設定（映像出力開始時の保険）

## 動作確認項目

- [x] エンコード済み 720p 動画がフルスクリーンで表示される（黒帯なし）
- [x] TS 動画が引き続きフルスクリーンで表示される（退行なし）
- [x] エミュレーターと実機の両方で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)