### PR TITLE
feat: 録画中コンテンツの追いかけ再生（内蔵プレーヤー対応）

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/DetailsActivity.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/DetailsActivity.kt
@@ -23,5 +23,6 @@ class DetailsActivity : FragmentActivity() {
         const val RECORDEDPROGRAM = "RecordedProgram"
         const val RECORDEDITEM = "RecordedItem"
         const val ACTIONID = "Action.id"
+        const val IS_HLS = "IsHls"
     }
 }

--- a/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
@@ -4,10 +4,14 @@ import android.content.Context
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.SurfaceView
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.leanback.app.PlaybackSupportFragment
 import androidx.leanback.app.PlaybackSupportFragmentGlueHost
 import androidx.leanback.app.VideoSupportFragment
@@ -19,9 +23,14 @@ import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.PlaybackControlsRow
 import com.daigorian.epcltvapp.epgstationcaller.EpgStation
 import com.daigorian.epcltvapp.epgstationcaller.RecordedProgram
+import com.daigorian.epcltvapp.epgstationv2caller.ApiErrorV2
 import com.daigorian.epcltvapp.epgstationv2caller.EpgStationV2
+import com.daigorian.epcltvapp.epgstationv2caller.HlsStream
 import com.daigorian.epcltvapp.epgstationv2caller.RecordedItem
 import org.videolan.libvlc.util.VLCVideoLayout
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 /** Handles video playback with media controls. */
 class PlaybackVideoFragment : PlaybackSupportFragment() {
@@ -29,6 +38,24 @@ class PlaybackVideoFragment : PlaybackSupportFragment() {
     var mVLCVideoLayout: VLCVideoLayout? = null
 
     private lateinit var mTransportControlGlue: MyPlaybackTransportControlGlue<VlcPlayerAdapter>
+
+    private var hlsStreamId: Int? = null
+    private val keepAliveHandler = Handler(Looper.getMainLooper())
+    private val keepAliveRunnable = object : Runnable {
+        override fun run() {
+            hlsStreamId?.let { id ->
+                EpgStationV2.api?.keepStream(id)?.enqueue(object : Callback<ApiErrorV2> {
+                    override fun onResponse(call: Call<ApiErrorV2>, response: Response<ApiErrorV2>) {
+                        Log.d(TAG, "HLS keep-alive sent for streamId=$id")
+                    }
+                    override fun onFailure(call: Call<ApiErrorV2>, t: Throwable) {
+                        Log.w(TAG, "HLS keep-alive failed for streamId=$id")
+                    }
+                })
+            }
+            keepAliveHandler.postDelayed(this, KEEP_ALIVE_INTERVAL_MS)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -63,19 +90,48 @@ class PlaybackVideoFragment : PlaybackSupportFragment() {
         mTransportControlGlue.isSeekEnabled = true   // TODO: VlcPlayerAdapter has property for seek capability
         mTransportControlGlue.playWhenPrepared()
 
-        val movieUrl = if(recordedProgram != null){
-            // EPGStation V1.x.x　
-            if (actionId == VideoDetailsFragment.ACTION_WATCH_ORIGINAL_TS) {
-                EpgStation.getTsVideoURL(recordedProgram.id.toString())
-            } else {
-                EpgStation.getEncodedVideoURL(recordedProgram.id.toString(),actionId.toString())
-            }
-        }else{
-            // EPGStation V2.x.x　
-            EpgStationV2.getVideoURL(actionId.toString())
-        }
+        val isHls = activity?.intent?.getBooleanExtra(DetailsActivity.IS_HLS, false) ?: false
 
-        playerAdapter.setDataSource(Uri.parse(movieUrl))
+        if (isHls && recordedItem != null) {
+            // 追いかけ再生: HLS ストリームを開始してから M3U8 URL をセット
+            EpgStationV2.api?.startRecordedHlsStream(actionId)?.enqueue(object : Callback<HlsStream> {
+                override fun onResponse(call: Call<HlsStream>, response: Response<HlsStream>) {
+                    val streamId = response.body()?.streamId
+                    if (streamId == null) {
+                        activity?.runOnUiThread {
+                            Toast.makeText(requireContext(), getString(R.string.hls_stream_start_failed), Toast.LENGTH_LONG).show()
+                        }
+                        return
+                    }
+                    hlsStreamId = streamId
+                    Log.d(TAG, "HLS stream started: streamId=$streamId")
+                    val m3u8Url = EpgStationV2.getHlsStreamUrl(streamId)
+                    activity?.runOnUiThread {
+                        playerAdapter.setDataSource(Uri.parse(m3u8Url))
+                        keepAliveHandler.postDelayed(keepAliveRunnable, KEEP_ALIVE_INTERVAL_MS)
+                    }
+                }
+                override fun onFailure(call: Call<HlsStream>, t: Throwable) {
+                    Log.e(TAG, "HLS stream start failed", t)
+                    activity?.runOnUiThread {
+                        Toast.makeText(requireContext(), getString(R.string.hls_stream_start_failed), Toast.LENGTH_LONG).show()
+                    }
+                }
+            })
+        } else {
+            val movieUrl = if (recordedProgram != null) {
+                // EPGStation V1.x.x
+                if (actionId == VideoDetailsFragment.ACTION_WATCH_ORIGINAL_TS) {
+                    EpgStation.getTsVideoURL(recordedProgram.id.toString())
+                } else {
+                    EpgStation.getEncodedVideoURL(recordedProgram.id.toString(), actionId.toString())
+                }
+            } else {
+                // EPGStation V2.x.x
+                EpgStationV2.getVideoURL(actionId.toString())
+            }
+            playerAdapter.setDataSource(Uri.parse(movieUrl))
+        }
     }
 
     override fun onCreateView(
@@ -97,6 +153,19 @@ class PlaybackVideoFragment : PlaybackSupportFragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        // HLS ストリームのクリーンアップ
+        keepAliveHandler.removeCallbacks(keepAliveRunnable)
+        hlsStreamId?.let { id ->
+            EpgStationV2.api?.stopStream(id)?.enqueue(object : Callback<ApiErrorV2> {
+                override fun onResponse(call: Call<ApiErrorV2>, response: Response<ApiErrorV2>) {
+                    Log.d(TAG, "HLS stream stopped: streamId=$id")
+                }
+                override fun onFailure(call: Call<ApiErrorV2>, t: Throwable) {
+                    Log.w(TAG, "HLS stream stop failed: streamId=$id")
+                }
+            })
+            hlsStreamId = null
+        }
         mVLCVideoLayout = null
         if (mTransportControlGlue.playerAdapter is VlcPlayerAdapter){
             mTransportControlGlue.playerAdapter.setVLCVideoLayout(mVLCVideoLayout)
@@ -106,6 +175,11 @@ class PlaybackVideoFragment : PlaybackSupportFragment() {
     override fun onPause() {
         super.onPause()
         mTransportControlGlue.pause()
+    }
+
+    companion object {
+        private const val TAG = "PlaybackVideoFragment"
+        private const val KEEP_ALIVE_INTERVAL_MS = 60_000L
     }
 
     class MyPlaybackTransportControlGlue<T: PlayerAdapter>(context:Context? , impl:T )

--- a/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
@@ -41,6 +41,15 @@ class PlaybackVideoFragment : PlaybackSupportFragment() {
 
     private var hlsStreamId: Int? = null
     private val keepAliveHandler = Handler(Looper.getMainLooper())
+    private val hlsRetryRunnable = Runnable {
+        val adapter = mTransportControlGlue.playerAdapter
+        if (!adapter.isPlaying()) {
+            Log.d(TAG, "HLS retry: VLC not playing, calling retryPlay()")
+            adapter.retryPlay()
+        } else {
+            Log.d(TAG, "HLS retry: VLC already playing, skip")
+        }
+    }
     private val keepAliveRunnable = object : Runnable {
         override fun run() {
             hlsStreamId?.let { id ->
@@ -107,8 +116,13 @@ class PlaybackVideoFragment : PlaybackSupportFragment() {
                     Log.d(TAG, "HLS stream started: streamId=$streamId")
                     val m3u8Url = EpgStationV2.getHlsStreamUrl(streamId)
                     activity?.runOnUiThread {
+                        Log.d(TAG, "Calling setDataSource: $m3u8Url")
                         playerAdapter.setDataSource(Uri.parse(m3u8Url))
-                        keepAliveHandler.postDelayed(keepAliveRunnable, KEEP_ALIVE_INTERVAL_MS)
+                        Log.d(TAG, "Calling playerAdapter.play() directly, isPrepared=${playerAdapter.isPrepared()}")
+                        mTransportControlGlue.playerAdapter.play()
+                        keepAliveHandler.post(keepAliveRunnable)
+                        // If M3U8 wasn't ready yet, retry after segments are generated
+                        keepAliveHandler.postDelayed(hlsRetryRunnable, HLS_RETRY_DELAY_MS)
                     }
                 }
                 override fun onFailure(call: Call<HlsStream>, t: Throwable) {
@@ -155,6 +169,7 @@ class PlaybackVideoFragment : PlaybackSupportFragment() {
         super.onDestroyView()
         // HLS ストリームのクリーンアップ
         keepAliveHandler.removeCallbacks(keepAliveRunnable)
+        keepAliveHandler.removeCallbacks(hlsRetryRunnable)
         hlsStreamId?.let { id ->
             EpgStationV2.api?.stopStream(id)?.enqueue(object : Callback<ApiErrorV2> {
                 override fun onResponse(call: Call<ApiErrorV2>, response: Response<ApiErrorV2>) {
@@ -179,7 +194,8 @@ class PlaybackVideoFragment : PlaybackSupportFragment() {
 
     companion object {
         private const val TAG = "PlaybackVideoFragment"
-        private const val KEEP_ALIVE_INTERVAL_MS = 60_000L
+        private const val KEEP_ALIVE_INTERVAL_MS = 10_000L
+        private const val HLS_RETRY_DELAY_MS = 15_000L
     }
 
     class MyPlaybackTransportControlGlue<T: PlayerAdapter>(context:Context? , impl:T )

--- a/app/src/main/java/com/daigorian/epcltvapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VideoDetailsFragment.kt
@@ -262,6 +262,12 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     )
                 )
             }
+            // 録画中の TS ファイルがある場合、追いかけ再生ボタンを追加
+            if (recordedItem.isRecording && recordedItem.videoFiles?.any { it.type == "ts" } == true) {
+                actionAdapter.add(
+                    Action(ACTION_WATCH_RECORDING_HLS, getString(R.string.play_catchup_hls))
+                )
+            }
         }
 
 
@@ -333,6 +339,17 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 }
                 ProgramInfoDialogFragment.newInstance(programName, bodyText)
                     .show(childFragmentManager, ProgramInfoDialogFragment.TAG)
+                return@OnActionClickedListener
+            }
+
+            if (action.id == ACTION_WATCH_RECORDING_HLS) {
+                val tsFile = mSelectedRecordedItem?.videoFiles?.firstOrNull { it.type == "ts" }
+                    ?: return@OnActionClickedListener
+                val intent = Intent(requireContext(), PlaybackActivity::class.java)
+                mSelectedRecordedItem?.let { intent.putExtra(DetailsActivity.RECORDEDITEM, it) }
+                intent.putExtra(DetailsActivity.ACTIONID, tsFile.id)
+                intent.putExtra(DetailsActivity.IS_HLS, true)
+                startActivity(intent)
                 return@OnActionClickedListener
             }
 
@@ -589,6 +606,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
 
         internal const val ACTION_WATCH_ORIGINAL_TS = 0L
         internal const val ACTION_SHOW_DESCRIPTION = -1L
+        internal const val ACTION_WATCH_RECORDING_HLS = -2L
 
         private const val DETAIL_THUMB_WIDTH = 274
         private const val DETAIL_THUMB_HEIGHT = 274

--- a/app/src/main/java/com/daigorian/epcltvapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VideoDetailsFragment.kt
@@ -262,8 +262,13 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     )
                 )
             }
-            // 録画中の TS ファイルがある場合、追いかけ再生ボタンを追加
-            if (recordedItem.isRecording && recordedItem.videoFiles?.any { it.type == "ts" } == true) {
+            // 録画中の TS ファイルがある場合、内蔵プレーヤー選択時のみ追いかけ再生ボタンを追加
+            val playerPkgName = PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getString(getString(R.string.pref_key_player), "")
+            if (recordedItem.isRecording &&
+                recordedItem.videoFiles?.any { it.type == "ts" } == true &&
+                playerPkgName == getString(R.string.pref_options_movie_player_val_INTERNAL)
+            ) {
                 actionAdapter.add(
                     Action(ACTION_WATCH_RECORDING_HLS, getString(R.string.play_catchup_hls))
                 )

--- a/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/VlcPlayerAdapter.kt
@@ -31,7 +31,11 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
      */
 
     // For LibVLC
-    private val args: ArrayList<String?> = arrayListOf("--verbose=3")
+    private val args: ArrayList<String?> = arrayListOf(
+        "--verbose=3",
+        "--network-caching=10000",  // 10s buffer for live HLS stability
+        "--live-caching=10000",
+    )
     private val mLibVLC: LibVLC = LibVLC(mContext, args)
     private val vlcPlayer = MediaPlayer(mLibVLC)
 
@@ -250,6 +254,18 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
     }
 
     /**
+     * Recreate Media from the current URI and start playing.
+     * Used to retry after EncounteredError without needing a new URI.
+     */
+    fun retryPlay() {
+        Log.d(TAG, "retryPlay() mMediaSourceUri=$mMediaSourceUri")
+        val uri = mMediaSourceUri ?: return
+        mMediaSourceUri = null  // Reset so setDataSource accepts same URI
+        setDataSource(uri)
+        vlcPlayer.play()
+    }
+
+    /**
      * Sets the media source of the player with a given URI.
      *
      * @return Returns `true` if uri represents a new media; `false`
@@ -282,10 +298,17 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
                     Log.d(TAG, "libvlc Event.MediaChanged:")
                 }
                 Event.Opening -> {
-                    Log.d(TAG, "libvlc Event.Opening")
+                    Log.d(TAG, "libvlc Event.Opening mInitialized=$mInitialized mHasDisplay=$mHasDisplay")
                     callback.onBufferingStateChanged(this@VlcPlayerAdapter, true)
 
                     if (mSurfaceHolderGlueHost == null || mHasDisplay) {
+                        // Display is still attached (e.g. HLS flow where setDataSource is called
+                        // after setVLCVideoLayout). Restore initialized so isPrepared() = true.
+                        if (!mInitialized && mHasDisplay) {
+                            Log.d(TAG, "Event.Opening: restoring mInitialized=true because mHasDisplay=true")
+                            mInitialized = true
+                        }
+                        Log.d(TAG, "Event.Opening: calling onPreparedStateChanged, isPrepared=${isPrepared()}")
                         callback.onPreparedStateChanged(this@VlcPlayerAdapter)
                     }
                 }
@@ -386,8 +409,9 @@ class VlcPlayerAdapter(var mContext: Context) : PlayerAdapter() {
      * [PlaybackGlueHost] provides SurfaceHolder.
      */
     override fun isPrepared(): Boolean {
-        // Log.d(TAG, "isPrepared() : "+ (mInitialized && (mSurfaceHolderGlueHost == null || mHasDisplay)) )
-        return mInitialized && (mSurfaceHolderGlueHost == null || mHasDisplay)
+        val result = mInitialized && (mSurfaceHolderGlueHost == null || mHasDisplay)
+        Log.d(TAG, "isPrepared()=$result mInitialized=$mInitialized mHasDisplay=$mHasDisplay mSurfaceHolderGlueHost=${mSurfaceHolderGlueHost != null}")
+        return result
     }
 
     /**

--- a/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/EpgStationV2.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/EpgStationV2.kt
@@ -56,6 +56,19 @@ object EpgStationV2 {
 
         @GET("channels")
         fun getChannels(): Call<List<ChannelItem>>
+
+        @GET("streams/recorded/{videoFileId}/hls")
+        fun startRecordedHlsStream(
+            @Path("videoFileId") videoFileId: Long,
+            @Query("ss") ss: Int = 0,
+            @Query("mode") mode: Int = 0
+        ): Call<HlsStream>
+
+        @DELETE("streams/{streamId}")
+        fun stopStream(@Path("streamId") streamId: Int): Call<ApiErrorV2>
+
+        @PUT("streams/{streamId}/keep")
+        fun keepStream(@Path("streamId") streamId: Int): Call<ApiErrorV2>
     }
 
 
@@ -129,5 +142,11 @@ object EpgStationV2 {
 
     fun getVideoURL(id:String):String{
         return baseUrl + "videos/" + id
+    }
+
+    fun getHlsStreamUrl(streamId: Int): String {
+        val url = URL(baseUrl)
+        val base = "${url.protocol}://${url.host}${if (url.port != -1) ":${url.port}" else ""}"
+        return "$base/streamfiles/stream$streamId.m3u8"
     }
 }

--- a/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/HlsStream.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/HlsStream.kt
@@ -1,0 +1,3 @@
+package com.daigorian.epcltvapp.epgstationv2caller
+
+data class HlsStream(val streamId: Int)

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -66,6 +66,7 @@
     <string name="delete_failed">削除に失敗しました</string>
     <string name="delete">削除</string>
     <string name="cancel">キャンセル</string>
+    <string name="play_catchup_hls">追いかけ再生(HLS)</string>
     <string name="no_subtitle">字幕なし</string>
     <string name="start_end_duration">%1$s ～ %2$s (%3$d分)</string>
     <string name="program_info">番組情報</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,6 +147,8 @@
     <string name="delete_failed">Delete failed</string>
     <string name="delete">Delete</string>
     <string name="cancel">Cancel</string>
+    <string name="play_catchup_hls">Catch-up Playback (HLS)</string>
+    <string name="hls_stream_start_failed">Failed to start HLS stream</string>
     <string name="no_subtitle">No subtitle</string>
     <string name="subtitle_off">Subtitle OFF</string>
     <string name="start_end_duration">%1$s - %2$s (%3$d min.)</string>


### PR DESCRIPTION
## Summary

- 録画中のコンテンツの詳細画面に「追いかけ再生(HLS)」ボタンを追加
- 内蔵プレーヤーでHLSストリーミング再生を実装（EPGStation V2 API連携）
- 外部プレーヤーが再生設定で選択されているときはボタンを非表示にする

## 実装内容

### 詳細画面 (VideoDetailsFragment)
- `isRecording=true` かつ TSファイルあり かつ 内蔵プレーヤー選択時のみボタンを表示
- ボタン押下で `PlaybackActivity` を HLS モードで起動

### 内蔵プレーヤー (PlaybackVideoFragment / VlcPlayerAdapter)
- EPGStation の `GET /api/streams/recorded/{id}/hls` でストリームを開始し M3U8 URL を取得
- 10秒間隔の keep-alive (`PUT /api/streams/{id}/keep`) でEPGStation側の15秒タイマーをリセット
- 画面離脱時に `DELETE /api/streams/{id}` でストリームを停止
- M3U8未準備時の15秒後自動リトライ (`hlsRetryRunnable`)
- VLC `Event.Opening` 時に `mInitialized` を復元し自動再生を修正
- `EncounteredError` 後の Media 再生成リトライ (`retryPlay`) を実装
- libVLC のネットワーク・ライブキャッシュを10秒に設定

### i18n
- 日本語ロケール文字列「追いかけ再生(HLS)」を追加

## 既知の制限

- **追いかけ再生中のシーク（スキップ）が動作しない** → 別途対応予定

## Test plan

- [x] 再生設定「内蔵プレーヤー」で録画中コンテンツの詳細画面を開き「追いかけ再生(HLS)」ボタンが表示される
- [x] ボタン押下で内蔵プレーヤーが起動し再生が自動で始まる
- [x] 再生中に詳細画面に戻るとHLSストリームが停止される
- [x] 再生設定が外部プレーヤーのときはボタンが表示されない
- [x] 日本語ロケール端末でボタン名が「追いかけ再生(HLS)」と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)