### PR TITLE
ストリームmodeをサーバー設定から動的解決するように変更

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -1,0 +1,50 @@
+# WIP: Issue #34 ストリームmode設定のハードコード解消
+
+## 目的
+
+録画追いかけHLS・ライブHLS・ライブMpegTSの3箇所で`mode`クエリパラメータが`0`固定になっている問題を解消する。
+`GET /api/config`の`streamConfig`からサーバーのプロファイル一覧を取得・キャッシュし、設定画面でユーザーが選択できるようにする。
+あわせて、ライブmpegts直送で無効化されているtsreadex+libaribcaptionのネイティブTS処理（#33対応でfalse固定）を、デフォルトON・トグル可能にする。
+
+詳細設計は plan ファイル参照（`C:\Users\daigo\.claude\plans\fuzzy-doodling-hejlsberg.md`）。
+
+## 設計の要点（Issue本文からの重要な変更点）
+
+- プロファイル選択の永続化は **index ではなく「プロファイル名」の文字列** で行う。config.ymlの並び順が変わってもユーザーの選択がズレないようにするため。
+- 「自動」選択肢は型ごとに意味をラベルに明記する:
+  - 録画追いかけHLS・ライブHLS: 「自動（サーバー設定の先頭）」
+  - ライブMpegTS: 「自動（無変換を優先）」
+- サーバー側の`mode`は必須パラメータ・範囲外は500エラー（`l3tnun/EPGStation`ソースで確認済み）。streamConfig未取得時のフォールバックは今と同じ`mode=0`。
+
+## 完了済み
+
+- [x] ブランチ作成・WIP.md作成
+- [x] `StreamConfig.kt` 新規作成（data class群）
+- [x] `EpgStationV2.kt`: `getConfig` API・`streamConfig`キャッシュ・`resolveHlsProfileIndex`/`resolveM2tsProfileIndex`追加
+- [x] `MainFragment.kt`: `EpgStationV2.fetchStreamConfig()`呼び出し追加
+- [x] `preferences.xml`: Stream Quality / TS Processing カテゴリ追加
+- [x] `strings.xml` + `values-ja-rJP/strings.xml`: 新規文字列リソース追加
+- [x] `SettingsFragment.kt`: 3つのListPreferenceへ動的にentries設定
+- [x] `PlaybackVideoFragment.kt`: mode解決・nativeTsProcessing反映
+
+## 残タスク
+
+- [ ] ユーザーによる動作確認（Android Studioビルド・実機/エミュレーター）
+- [ ] 動作確認OKならコミット → PR作成
+
+## 実装メモ（動作確認時に見るポイント）
+
+- Settings → Playback Settings に「Stream Quality」（3つのプロファイル選択）と「TS Processing」（ネイティブTS処理トグル）が追加されている
+- プロファイル選択肢の先頭は常に自動ラベル（録画/ライブHLSは「自動（サーバー設定の先頭）」、ライブTSは「自動（無変換を優先）」）。以降がサーバーから取得した実プロファイル名
+- 選択値はプロファイル「名前」で保存される。config.ymlの並び順を変えても、名前が存在する限りユーザーの選択は追従する
+
+## 動作確認中に見つかった修正
+
+- ネイティブTS処理（tsreadex+ARIB字幕）のデフォルトは、Issue #34本文では「true」提案だったが、**falseに変更**（従来通りバイパス）。
+  - 初回動作確認時にライブTS再生でスピナーが止まらない・ライブHLSで「Failed to start HLS Stream」が発生。原因はEPGStation側でチューナーが全て使用中だったことと判明（コード側のバグではない）。
+  - ただしユーザー判断として、#33のクラッシュ疑いが実機で未解決のため、念のためデフォルトはOFFのまま維持し、必要な人だけ設定でONにできるようにした。
+
+## 重要な決定事項
+
+- `recorded.encoded.hls`ではなく`recorded.ts.hls`を使う（Issue本文通り、`isEncodedVideo`判定はサーバー側が自動分岐するためアプリは関知しない）
+- ビルドコマンドはClaudeが実行しない。Android Studioでユーザーが手動ビルドする。

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -239,6 +239,7 @@ class MainFragment : BrowseSupportFragment() {
                             Log.d(TAG, "initEPGStationApi() detect Version 2.x.x")
                             EpgStationV2.initAPI(baseUrl)
                             EpgStationV2.fetchChannels()
+                            EpgStationV2.fetchStreamConfig()
                             loadRows()
                         } else {
                             //Version 1で初期化

--- a/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
@@ -127,9 +127,6 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         val isLive = activity?.intent?.getBooleanExtra(DetailsActivity.IS_LIVE, false) ?: false
         // 実験的機能: mpegts直送ライブ再生（チャンネルカード長押しから起動）
         isLiveMpegTs = activity?.intent?.getBooleanExtra(DetailsActivity.IS_LIVE_MPEGTS, false) ?: false
-        // 切り分け中: mpegts直送はいったんネイティブTS処理(tsreadex/ARIB字幕)を通さず、
-        // ExoPlayer標準の仕組みだけで再生できるか確認する。isTsContentには含めない。
-        isTsContent = activity?.intent?.getBooleanExtra(DetailsActivity.IS_TS_CONTENT, false) ?: false
         val isAnyLive = isLive || isLiveMpegTs
         liveChannelId = activity?.intent?.getLongExtra(DetailsActivity.CHANNEL_ID, -1L) ?: -1L
         val liveChannelName = activity?.intent?.getStringExtra(DetailsActivity.CHANNEL_NAME)
@@ -139,6 +136,28 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         captionEnabled = prefs.getBoolean(PREF_CAPTION_ENABLED, false)
         superimposeEnabled = prefs.getBoolean(PREF_SUPERIMPOSE_ENABLED, true)
         preferSubAudio = prefs.getBoolean(PREF_SUB_AUDIO, false)
+
+        // ライブmpegts直送は#33のクラッシュ疑いにより長らくネイティブTS処理(tsreadex/ARIB字幕)を
+        // 強制バイパスしていたが、Issue #34でユーザー切り替え可能な設定にした。
+        // #33が実機で未解決のため、デフォルトはOFF（従来通りバイパス）とし、必要な人だけONにする。
+        val nativeTsProcessingEnabled = prefs.getBoolean(getString(R.string.pref_key_native_ts_processing), false)
+        isTsContent = ((activity?.intent?.getBooleanExtra(DetailsActivity.IS_TS_CONTENT, false) ?: false) || isLiveMpegTs) &&
+                nativeTsProcessingEnabled
+
+        // ストリームプロファイル選択（Issue #34）: config.ymlの並び順ではなくプロファイル名で
+        // ユーザーの選択を永続化してあるので、都度最新のstreamConfigから該当indexを解決する。
+        val recordedHlsMode = EpgStationV2.resolveHlsProfileIndex(
+            prefs.getString(getString(R.string.pref_key_recorded_hls_profile), ""),
+            EpgStationV2.streamConfig?.recorded?.ts?.hls.orEmpty()
+        )
+        val liveHlsMode = EpgStationV2.resolveHlsProfileIndex(
+            prefs.getString(getString(R.string.pref_key_live_hls_profile), ""),
+            EpgStationV2.streamConfig?.live?.ts?.hls.orEmpty()
+        )
+        val liveMpegTsMode = EpgStationV2.resolveM2tsProfileIndex(
+            prefs.getString(getString(R.string.pref_key_live_mpegts_profile), ""),
+            EpgStationV2.streamConfig?.live?.ts?.m2ts.orEmpty()
+        )
 
         // Build ExoPlayer
         trackSelector = DefaultTrackSelector(requireContext())
@@ -202,22 +221,21 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         val okHttpClient: OkHttpClient
 
         if (isLiveMpegTs && liveChannelId >= 0) {
-            val mpegTsUrl = EpgStationV2.getLiveMpegTsUrl(liveChannelId)
+            val mpegTsUrl = EpgStationV2.getLiveMpegTsUrl(liveChannelId, liveMpegTsMode)
             okHttpClient = buildOkHttpClient(mpegTsUrl)
-            // 切り分け中: 字幕なしのプレーン再生でクラッシュの原因がネイティブTS処理側か確認する
-            startDirectPlayback(mpegTsUrl, okHttpClient, false)
+            startDirectPlayback(mpegTsUrl, okHttpClient, isTsContent)
             return
         }
 
         if (isLive && liveChannelId >= 0) {
             okHttpClient = buildOkHttpClient(EpgStationV2.getVideoURL("0"))
-            startLiveHlsPlayback(liveChannelId, okHttpClient)
+            startLiveHlsPlayback(liveChannelId, okHttpClient, liveHlsMode)
             return
         }
 
         if (isHls && recordedItem != null) {
             okHttpClient = buildOkHttpClient(EpgStationV2.getVideoURL("0"))
-            startHlsPlayback(actionId, okHttpClient)
+            startHlsPlayback(actionId, okHttpClient, recordedHlsMode)
             return
         }
 
@@ -301,8 +319,8 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         exoPlayer?.playWhenReady = true
     }
 
-    private fun startHlsPlayback(actionId: Long, httpClient: OkHttpClient) {
-        EpgStationV2.api?.startRecordedHlsStream(actionId)?.enqueue(object : Callback<HlsStream> {
+    private fun startHlsPlayback(actionId: Long, httpClient: OkHttpClient, mode: Int) {
+        EpgStationV2.api?.startRecordedHlsStream(actionId, mode = mode)?.enqueue(object : Callback<HlsStream> {
             override fun onResponse(call: Call<HlsStream>, response: Response<HlsStream>) {
                 val streamId = response.body()?.streamId
                 if (streamId == null) {
@@ -346,8 +364,8 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         })
     }
 
-    private fun startLiveHlsPlayback(channelId: Long, httpClient: OkHttpClient) {
-        EpgStationV2.api?.startLiveHlsStream(channelId)?.enqueue(object : Callback<HlsStream> {
+    private fun startLiveHlsPlayback(channelId: Long, httpClient: OkHttpClient, mode: Int) {
+        EpgStationV2.api?.startLiveHlsStream(channelId, mode = mode)?.enqueue(object : Callback<HlsStream> {
             override fun onResponse(call: Call<HlsStream>, response: Response<HlsStream>) {
                 val streamId = response.body()?.streamId
                 if (streamId == null) {

--- a/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SettingsFragment.kt
@@ -8,6 +8,8 @@ import androidx.leanback.preference.LeanbackPreferenceFragment
 import androidx.leanback.preference.LeanbackSettingsFragment
 import androidx.preference.*
 import androidx.preference.DialogPreference.TargetFragment
+import com.daigorian.epcltvapp.epgstationv2caller.EpgStationV2
+import com.daigorian.epcltvapp.epgstationv2caller.M2tsStreamParam
 
 
 class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
@@ -129,6 +131,58 @@ class SettingsFragment : LeanbackSettingsFragment(), TargetFragment {
                     Toast.makeText(activity, getString(R.string.history_cleared), Toast.LENGTH_SHORT).show()
                     true
                 }
+
+            // ストリームプロファイル選択（Issue #34）: サーバーから取得したプロファイル名は
+            // 静的リソースにできないため、EpgStationV2にキャッシュされたstreamConfigから動的に構築する。
+            // 未取得(null)の場合は自動ラベルのみのリストになる（表示は壊れない）。
+            val streamConfig = EpgStationV2.streamConfig
+
+            val recordedHlsProfilePref = preferenceScreen.findPreference(getText(R.string.pref_key_recorded_hls_profile)) as ListPreference?
+            recordedHlsProfilePref?.let {
+                val (labels, values) = buildHlsProfileEntries(
+                    streamConfig?.recorded?.ts?.hls.orEmpty(),
+                    getString(R.string.stream_profile_auto_first)
+                )
+                it.entries = labels
+                it.entryValues = values
+            }
+
+            val liveHlsProfilePref = preferenceScreen.findPreference(getText(R.string.pref_key_live_hls_profile)) as ListPreference?
+            liveHlsProfilePref?.let {
+                val (labels, values) = buildHlsProfileEntries(
+                    streamConfig?.live?.ts?.hls.orEmpty(),
+                    getString(R.string.stream_profile_auto_first)
+                )
+                it.entries = labels
+                it.entryValues = values
+            }
+
+            val liveMpegTsProfilePref = preferenceScreen.findPreference(getText(R.string.pref_key_live_mpegts_profile)) as ListPreference?
+            liveMpegTsProfilePref?.let {
+                val (labels, values) = buildM2tsProfileEntries(
+                    streamConfig?.live?.ts?.m2ts.orEmpty(),
+                    getString(R.string.stream_profile_auto_unconverted)
+                )
+                it.entries = labels
+                it.entryValues = values
+            }
+        }
+
+        private fun buildHlsProfileEntries(names: List<String>, autoLabel: String): Pair<Array<CharSequence>, Array<CharSequence>> {
+            val labels = mutableListOf<CharSequence>(autoLabel)
+            val values = mutableListOf<CharSequence>("")
+            names.forEach { labels.add(it); values.add(it) }
+            return labels.toTypedArray() to values.toTypedArray()
+        }
+
+        private fun buildM2tsProfileEntries(profiles: List<M2tsStreamParam>, autoLabel: String): Pair<Array<CharSequence>, Array<CharSequence>> {
+            val labels = mutableListOf<CharSequence>(autoLabel)
+            val values = mutableListOf<CharSequence>("")
+            profiles.forEach { p ->
+                labels.add(if (p.isUnconverted) "${p.name} (無変換)" else p.name)
+                values.add(p.name)
+            }
+            return labels.toTypedArray() to values.toTypedArray()
         }
 
         private fun enableCustomBaseUrlUI(boolean: Boolean) {

--- a/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/EpgStationV2.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/EpgStationV2.kt
@@ -58,6 +58,9 @@ object EpgStationV2 {
         @GET("channels")
         fun getChannels(): Call<List<ChannelItem>>
 
+        @GET("config")
+        fun getConfig(): Call<ConfigResponse>
+
         @GET("schedules/broadcasting")
         fun getScheduleOnAir(
             @Query("isHalfWidth") isHalfWidth: Boolean = true
@@ -103,6 +106,7 @@ object EpgStationV2 {
     var api: ApiInterface? = null
     var authForGlide : LazyHeaders? = null
     var channelMap: Map<Long, String> = emptyMap()
+    var streamConfig: StreamConfig? = null
 
     fun fetchChannels() {
         api?.getChannels()?.enqueue(object : Callback<List<ChannelItem>> {
@@ -113,6 +117,40 @@ object EpgStationV2 {
             }
             override fun onFailure(call: Call<List<ChannelItem>>, t: Throwable) {}
         })
+    }
+
+    fun fetchStreamConfig() {
+        api?.getConfig()?.enqueue(object : Callback<ConfigResponse> {
+            override fun onResponse(call: Call<ConfigResponse>, response: retrofit2.Response<ConfigResponse>) {
+                streamConfig = response.body()?.streamConfig
+            }
+            override fun onFailure(call: Call<ConfigResponse>, t: Throwable) {}
+        })
+    }
+
+    /**
+     * ユーザーが選んだプロファイル名からmodeインデックスを解決する。
+     * config.ymlの並び順が変わってもユーザーの選択がズレないよう、indexではなく名前で永続化・検索する。
+     * selectedNameがnull/空文字/該当なしの場合は先頭(index 0)にフォールバックする。
+     */
+    fun resolveHlsProfileIndex(selectedName: String?, profileNames: List<String>): Int {
+        if (!selectedName.isNullOrEmpty()) {
+            val idx = profileNames.indexOf(selectedName)
+            if (idx >= 0) return idx
+        }
+        return 0
+    }
+
+    /**
+     * ライブMpegTS用。該当なしの場合はisUnconverted(無変換)のプロファイルを優先し、無ければ先頭にフォールバックする。
+     */
+    fun resolveM2tsProfileIndex(selectedName: String?, profiles: List<M2tsStreamParam>): Int {
+        if (!selectedName.isNullOrEmpty()) {
+            val idx = profiles.indexOfFirst { it.name == selectedName }
+            if (idx >= 0) return idx
+        }
+        val unconverted = profiles.indexOfFirst { it.isUnconverted }
+        return if (unconverted >= 0) unconverted else 0
     }
 
     fun initAPI(_baseUrl:String){

--- a/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/StreamConfig.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/StreamConfig.kt
@@ -1,0 +1,24 @@
+package com.daigorian.epcltvapp.epgstationv2caller
+
+data class ConfigResponse(val streamConfig: StreamConfig? = null)
+
+data class StreamConfig(
+    val live: LiveStreamConfig? = null,
+    val recorded: RecordedStreamConfig? = null
+)
+
+data class LiveStreamConfig(val ts: LiveTsConfig? = null)
+
+data class LiveTsConfig(
+    val m2ts: List<M2tsStreamParam> = emptyList(),
+    val hls: List<String> = emptyList()
+)
+
+data class M2tsStreamParam(
+    val name: String = "",
+    val isUnconverted: Boolean = false
+)
+
+data class RecordedStreamConfig(val ts: RecordedTsConfig? = null)
+
+data class RecordedTsConfig(val hls: List<String> = emptyList())

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -88,4 +88,16 @@
     <string name="program_info">番組情報</string>
     <string name="close">閉じる</string>
 
+    <!-- Stream profile settings (Issue #34) -->
+    <string name="pref_category_stream_profile">ストリーム画質</string>
+    <string name="pref_category_ts_processing">TS処理</string>
+
+    <string name="recorded_hls_profile">録画追いかけHLSプロファイル</string>
+    <string name="live_hls_profile">ライブHLSプロファイル</string>
+    <string name="live_mpegts_profile">ライブTSプロファイル</string>
+    <string name="native_ts_processing">ネイティブTS処理 (tsreadex + ARIB字幕)</string>
+
+    <string name="stream_profile_auto_first">自動（サーバー設定の先頭）</string>
+    <string name="stream_profile_auto_unconverted">自動（無変換を優先）</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,22 @@
     <string name="program_info">Program Info</string>
     <string name="close">Close</string>
 
+    <!-- Stream profile settings (Issue #34) -->
+    <string name="pref_category_stream_profile">Stream Quality</string>
+    <string name="pref_category_ts_processing">TS Processing</string>
+
+    <string name="pref_key_recorded_hls_profile" translatable="false">KEY_RECORDED_HLS_PROFILE</string>
+    <string name="recorded_hls_profile">Catch-up HLS Profile</string>
+    <string name="pref_key_live_hls_profile" translatable="false">KEY_LIVE_HLS_PROFILE</string>
+    <string name="live_hls_profile">Live HLS Profile</string>
+    <string name="pref_key_live_mpegts_profile" translatable="false">KEY_LIVE_MPEGTS_PROFILE</string>
+    <string name="live_mpegts_profile">Live TS Profile</string>
+    <string name="pref_key_native_ts_processing" translatable="false">KEY_NATIVE_TS_PROCESSING</string>
+    <string name="native_ts_processing">Native TS Processing (tsreadex + ARIB caption)</string>
+
+    <string name="stream_profile_auto_first">Auto (server\'s first profile)</string>
+    <string name="stream_profile_auto_unconverted">Auto (prefer unconverted)</string>
+
 
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -50,6 +50,42 @@
             app:useSimpleSummaryProvider="true"
             />
 
+        <PreferenceCategory
+            app:title="@string/pref_category_stream_profile">
+
+            <ListPreference
+                app:key=         "@string/pref_key_recorded_hls_profile"
+                app:defaultValue=""
+                app:title=       "@string/recorded_hls_profile"
+                app:useSimpleSummaryProvider="true"
+                />
+
+            <ListPreference
+                app:key=         "@string/pref_key_live_hls_profile"
+                app:defaultValue=""
+                app:title=       "@string/live_hls_profile"
+                app:useSimpleSummaryProvider="true"
+                />
+
+            <ListPreference
+                app:key=         "@string/pref_key_live_mpegts_profile"
+                app:defaultValue=""
+                app:title=       "@string/live_mpegts_profile"
+                app:useSimpleSummaryProvider="true"
+                />
+
+        </PreferenceCategory>
+
+        <PreferenceCategory
+            app:title="@string/pref_category_ts_processing">
+
+            <SwitchPreference
+                app:key=         "@string/pref_key_native_ts_processing"
+                app:defaultValue="false"
+                app:title=       "@string/native_ts_processing" />
+
+        </PreferenceCategory>
+
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
## Summary

- 録画追いかけHLS・ライブHLS・ライブMpegTSのmodeパラメータが`0`固定で、サーバーの`config.yml`のプロファイル順序に暗黙依存していた問題を解消（closes #34）
- `GET /api/config`の`streamConfig`を取得・キャッシュし、設定画面（Playback Settings → Stream Quality）から3箇所それぞれプロファイルを選択できるようにした
  - 選択肢の先頭には型ごとに意味を明記した自動選択肢を用意（録画/ライブHLSは「自動（サーバー設定の先頭）」、ライブTSは「自動（無変換を優先）」）
  - 選択値は**プロファイル名**で永続化し、再生時に最新の`streamConfig`から都度indexを解決する（`config.yml`の並び順が変わってもユーザーの選択がズレない）
- あわせて、ライブmpegts直送で無効化されていたネイティブTS処理（tsreadex + ARIB字幕、#33のクラッシュ疑いにより`false`固定）をユーザー切り替え可能な設定（Playback Settings → TS Processing）にした
  - #33が実機で未解決のため、デフォルトは従来通りOFF（バイパス）を維持し、必要な人だけONにできる

## Test plan

- [x] 録画追いかけHLS再生（デフォルト＝自動選択）
- [x] ライブHLS再生（デフォルト＝自動選択）
- [x] ライブMpegTS直送再生（デフォルト＝自動選択）
- [x] Settingsで具体的なプロファイルを選択した状態での再生反映
- [x] サーバー未接続時にSettings画面を開いてもクラッシュしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)