### PR TITLE
収録済みオリジナルTS再生でシークを可能にする

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -65,6 +66,10 @@ class PlaybackVideoFragment : VideoSupportFragment() {
     private var captionHandle: Long = 0
     private var superimposeHandle: Long = 0
     private val mainHandler = Handler(Looper.getMainLooper())
+    // 字幕PES処理・遅延レンダリングのHandlerコールバックに付けるトークン。
+    // シーク時にmainHandler全体ではなくこれらだけを選択的にキャンセルするために使う
+    // (mainHandlerは他の目的にも使い回している共有インスタンスのため)。
+    private val captionCallbackToken = Any()
 
     // Persisted toggle states
     private var captionEnabled = false
@@ -77,6 +82,17 @@ class PlaybackVideoFragment : VideoSupportFragment() {
 
     // Content type
     private var isTsContent = false
+    // ARIB字幕/デュアルモノ副音声を扱うtsreadexネイティブフィルタを使うかどうか。
+    // isTsContentのサブセット(TSでなければ常にfalse)。
+    private var useNativeTsProcessing = false
+
+    // TS seek support (録画オリジナルTSのみ)
+    private var tsSeekAdapter: TsSeekPlayerAdapter? = null
+    private var tsSeekUrl: String? = null
+    private var tsSeekHttpClient: OkHttpClient? = null
+    private var tsSeekDataProvider: TsSeekDataProvider? = null
+    private val tsProbeExecutor: java.util.concurrent.ExecutorService =
+        java.util.concurrent.Executors.newSingleThreadExecutor()
 
     // Live viewing state
     private var liveChannelId: Long = -1L
@@ -137,12 +153,17 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         superimposeEnabled = prefs.getBoolean(PREF_SUPERIMPOSE_ENABLED, true)
         preferSubAudio = prefs.getBoolean(PREF_SUB_AUDIO, false)
 
-        // ライブmpegts直送は#33のクラッシュ疑いにより長らくネイティブTS処理(tsreadex/ARIB字幕)を
-        // 強制バイパスしていたが、Issue #34でユーザー切り替え可能な設定にした。
-        // #33が実機で未解決のため、デフォルトはOFF（従来通りバイパス）とし、必要な人だけONにする。
-        val nativeTsProcessingEnabled = prefs.getBoolean(getString(R.string.pref_key_native_ts_processing), false)
-        isTsContent = ((activity?.intent?.getBooleanExtra(DetailsActivity.IS_TS_CONTENT, false) ?: false) || isLiveMpegTs) &&
-                nativeTsProcessingEnabled
+        // isTsContent は「TSファイルかどうか」のみを表すフラグ。
+        // ネイティブ処理(tsreadex/ARIB字幕/デュアルモノ副音声)を使うかどうかは
+        // useNativeTsProcessing として別管理する——TS向けシーク機能はネイティブ処理を
+        // 使わなくても(生バイトを直接読むだけなので)動作するため、両者は独立している。
+        //
+        // ライブmpegts直送は#33のクラッシュ疑いにより長らくネイティブTS処理を強制バイパス
+        // していたが、Issue #34でユーザー切り替え可能な設定にした。#33が実機で未解決のため、
+        // デフォルトはOFF（従来通りバイパス）とし、必要な人だけONにする。
+        val nativeTsProcessingPref = prefs.getBoolean(getString(R.string.pref_key_native_ts_processing), false)
+        isTsContent = (activity?.intent?.getBooleanExtra(DetailsActivity.IS_TS_CONTENT, false) ?: false) || isLiveMpegTs
+        useNativeTsProcessing = isTsContent && nativeTsProcessingPref
 
         // ストリームプロファイル選択（Issue #34）: config.ymlの並び順ではなくプロファイル名で
         // ユーザーの選択を永続化してあるので、都度最新のstreamConfigから該当indexを解決する。
@@ -204,16 +225,29 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         })
 
         // Leanback glue
-        val playerAdapter = LeanbackPlayerAdapter(requireContext(), exoPlayer!!, UPDATE_PERIOD_MS)
+        // 録画オリジナルTS再生時は、TsReadexDataSource が duration を C.TIME_UNSET として
+        // 隠しているため、TsProbe の実測値とシーク時のオフセットを自前管理できる
+        // TsSeekPlayerAdapter を使う（LeanbackPlayerAdapter は final のため継承不可）。
+        val playerAdapter: PlayerAdapter = if (isTsContent && !isAnyLive) {
+            TsSeekPlayerAdapter(exoPlayer!!, UPDATE_PERIOD_MS) { targetMs ->
+                performTsSeek(targetMs)
+            }.also { tsSeekAdapter = it }
+        } else {
+            LeanbackPlayerAdapter(requireContext(), exoPlayer!!, UPDATE_PERIOD_MS)
+        }
         val glueHost = VideoSupportFragmentGlueHost(this@PlaybackVideoFragment)
 
         mTransportControlGlue = MyPlaybackTransportControlGlue(
-            activity, playerAdapter, isTsContent, isAnyLive, captionEnabled, superimposeEnabled, preferSubAudio, hasSubAudio
+            activity, playerAdapter, useNativeTsProcessing, isAnyLive, captionEnabled, superimposeEnabled, preferSubAudio, hasSubAudio
         )
         mTransportControlGlue.host = glueHost
         mTransportControlGlue.title = recordedProgram?.name ?: recordedItem?.name ?: liveChannelName
         mTransportControlGlue.subtitle = recordedProgram?.description ?: recordedItem?.description
-        mTransportControlGlue.isSeekEnabled = !isAnyLive
+        // 録画オリジナルTSはシーク点テーブルの構築が終わるまでシーク不可にする
+        // (テーブル未完成の間にシーク操作されると、Leanbackのデフォルトの1%刻み挙動＋
+        // 都度のバイト位置探索という避けたかった経路に落ちてしまうため)。
+        // テーブル完成後に startTsProbing() 内で true に切り替える。
+        mTransportControlGlue.isSeekEnabled = if (isTsContent && !isAnyLive) false else !isAnyLive
         mTransportControlGlue.playWhenPrepared()
 
         // Build OkHttpClient with auth if needed
@@ -223,7 +257,7 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         if (isLiveMpegTs && liveChannelId >= 0) {
             val mpegTsUrl = EpgStationV2.getLiveMpegTsUrl(liveChannelId, liveMpegTsMode)
             okHttpClient = buildOkHttpClient(mpegTsUrl)
-            startDirectPlayback(mpegTsUrl, okHttpClient, isTsContent)
+            startDirectPlayback(mpegTsUrl, okHttpClient, isTsContent, useNativeTsProcessing)
             return
         }
 
@@ -251,7 +285,12 @@ class PlaybackVideoFragment : VideoSupportFragment() {
 
         okHttpClient = buildOkHttpClient(movieUrl)
         val cleanUrl = stripAuthFromUrl(movieUrl)
-        startDirectPlayback(cleanUrl, okHttpClient, isTsContent)
+        startDirectPlayback(cleanUrl, okHttpClient, isTsContent, useNativeTsProcessing)
+        if (isTsContent) {
+            tsSeekUrl = cleanUrl
+            tsSeekHttpClient = okHttpClient
+            startTsProbing(cleanUrl, okHttpClient)
+        }
     }
 
     override fun onCreateView(
@@ -260,7 +299,7 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         savedInstanceState: Bundle?
     ): View? {
         val root = super.onCreateView(inflater, container, savedInstanceState) as ViewGroup?
-        if (isTsContent) {
+        if (useNativeTsProcessing) {
             overlayView = SubtitleOverlayView(requireContext()).apply {
                 layoutParams = ViewGroup.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
@@ -303,11 +342,22 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         })
     }
 
-    private fun startDirectPlayback(url: String, httpClient: OkHttpClient, isTsContent: Boolean) {
+    private fun startDirectPlayback(
+        url: String,
+        httpClient: OkHttpClient,
+        isTsContent: Boolean,
+        useNativeTsProcessing: Boolean,
+    ) {
         val dataSourceFactory = OkHttpDataSource.Factory(httpClient)
         val mediaSource = if (isTsContent) {
-            val tsFactory = TsReadexDataSource.Factory(dataSourceFactory)
-            setupCaptionListeners(tsFactory)
+            // TsReadexDataSource は startByteOffset によるシーク制御を担うため、
+            // ネイティブ処理(ARIB字幕等)のオン/オフにかかわらず常に経由させる。
+            val tsFactory = TsReadexDataSource.Factory(dataSourceFactory).apply {
+                nativeProcessingEnabled = useNativeTsProcessing
+            }
+            if (useNativeTsProcessing) {
+                setupCaptionListeners(tsFactory)
+            }
             ProgressiveMediaSource.Factory(tsFactory)
                 .createMediaSource(MediaItem.fromUri(url))
         } else {
@@ -317,6 +367,118 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         exoPlayer?.setMediaSource(mediaSource)
         exoPlayer?.prepare()
         exoPlayer?.playWhenReady = true
+    }
+
+    /**
+     * 録画オリジナルTSのシーク対応: ファイル先頭・末尾を軽量プロービングして実測の
+     * 総時間を求める。EPGStationのメタデータ(番組時間・ファイルサイズ)は使わない
+     * ——録画がエラー等で途中終了し、メタデータと実データが乖離するケースがあるため。
+     */
+    private fun startTsProbing(url: String, client: OkHttpClient) {
+        tsProbeExecutor.execute {
+            val fileSize = TsProbe.fetchFileSize(url, client)
+            val head = if (fileSize != null) TsProbe.probeHead(url, client) else null
+            if (fileSize == null || head == null) {
+                Log.w(TAG, "startTsProbing: head probe failed, seek stays disabled")
+                return@execute
+            }
+            val tail = TsProbe.probeTail(url, client, fileSize, head.pcrPid)
+            if (tail == null) {
+                Log.w(TAG, "startTsProbing: tail probe failed, seek stays disabled")
+                return@execute
+            }
+            if (tail.timeMs - head.firstPcr.timeMs <= 0) {
+                Log.w(TAG, "startTsProbing: invalid duration=${tail.timeMs - head.firstPcr.timeMs}")
+                return@execute
+            }
+            // head/tailの2点だけでdurationとシークを即座に有効化する(再生開始を待たせない)。
+            // 各シーク位置の正確なバイト位置はここでは求めず、確定時に1回だけ軽量プローブして
+            // 補正する(performTsSeek参照)。これにより起動時に必要なプロービングは
+            // fetchFileSize+probeHead+probeTailの3リクエストのみで済む。
+            val provider = TsSeekDataProvider(
+                fileSize, head.pcrPid, head.firstPcr, tail, SEEK_POINT_INTERVAL_MS, SEEK_POINT_COUNT_MAX
+            ) {
+                // Leanbackがシーク開始時に無条件でpause()する挙動を打ち消す(直前に再生中だった場合のみ再開)。
+                // シークバーへ移動しただけで再生が止まると「シークが実行された」と誤解させてしまうため。
+                tsSeekAdapter?.resumePlaybackIfWasPlaying()
+            }
+            mainHandler.post {
+                if (!isAdded) return@post
+                tsSeekDataProvider = provider
+                tsSeekAdapter?.setKnownDuration(provider.durationMs)
+                mTransportControlGlue.setSeekProvider(provider)
+                mTransportControlGlue.isSeekEnabled = true
+                Log.d(TAG, "startTsProbing: seek ready (${provider.seekPositionCount} points), durationMs=${provider.durationMs}")
+            }
+        }
+    }
+
+    /**
+     * シークバー確定(DPAD_CENTER/ENTER)時にTsSeekPlayerAdapterから呼ばれるエントリポイント。
+     *
+     * PlaybackSeekDataProvider(TsSeekDataProvider)を設定している間、LeanbackはD-pad操作の
+     * 途中経過ではPlayerAdapter.seekTo()を呼ばず、確定時に1回だけ呼ぶ。ここでは概算バイト位置
+     * (線形補間)を求めた上で、その近傍を1回だけ軽量プローブして実際の位置に補正する。
+     *
+     * 確定直後(mIsSeekがfalseに変わり通常ポーリングが再開する瞬間)から補正プローブ完了までの
+     * 短い空白期間、シークバーが一瞬古い位置に戻ってから正しい位置へ進むという不自然な動きに
+     * なるのを防ぐため、notifySeekPending()で概算位置を即座に(ネットワークI/O前に)反映する。
+     */
+    private fun performTsSeek(targetPositionMs: Long) {
+        val provider = tsSeekDataProvider ?: return
+        val url = tsSeekUrl ?: return
+        val client = tsSeekHttpClient ?: return
+        val clampedTarget = targetPositionMs.coerceIn(0, provider.durationMs)
+        val guessByteOffset = provider.estimateByteOffset(clampedTarget)
+        tsSeekAdapter?.notifySeekPending(clampedTarget)
+        tsProbeExecutor.execute {
+            val refined = TsProbe.refineSeekPoint(url, client, provider.fileSize, provider.pcrPid, guessByteOffset)
+            mainHandler.post {
+                if (!isAdded) return@post
+                if (refined != null) {
+                    restartTsPlaybackAt(refined.byteOffset, provider.toRelativeMs(refined.timeMs))
+                } else {
+                    // 補正プローブに失敗した場合は概算値のまま着地する(何もしないよりまし)
+                    Log.w(TAG, "performTsSeek: refine probe failed, falling back to estimate")
+                    restartTsPlaybackAt(guessByteOffset, clampedTarget)
+                }
+            }
+        }
+    }
+
+    /** 解決したバイト位置から MediaSource を作り直し、疑似シークを実行する。 */
+    private fun restartTsPlaybackAt(byteOffset: Long, newPositionOffsetMs: Long) {
+        val url = tsSeekUrl ?: return
+        val client = tsSeekHttpClient ?: return
+        // 一時停止中にシークした場合は一時停止のままにする(自動再開させない)
+        val wasPlaying = exoPlayer?.playWhenReady ?: true
+        // シーク前の字幕PES処理・遅延レンダリングコールバックが残っていると、シーク後も
+        // 古い字幕がしばらく表示され続けてしまうため、キャンセルした上でオーバーレイと
+        // デコーダ内部状態(表示継続時間等)の両方をクリアする。
+        mainHandler.removeCallbacksAndMessages(captionCallbackToken)
+        overlayView?.clearCaptions()
+        overlayView?.clearSuperimpose()
+        if (captionHandle != 0L) AribCaptionFilter.flush(captionHandle)
+        if (superimposeHandle != 0L) AribCaptionFilter.flush(superimposeHandle)
+        val dataSourceFactory = OkHttpDataSource.Factory(client)
+        val tsFactory = TsReadexDataSource.Factory(dataSourceFactory).apply {
+            startByteOffset = byteOffset
+            nativeProcessingEnabled = useNativeTsProcessing
+        }
+        if (useNativeTsProcessing) {
+            setupCaptionListeners(tsFactory)
+        }
+        val mediaSource = ProgressiveMediaSource.Factory(tsFactory).createMediaSource(MediaItem.fromUri(url))
+        exoPlayer?.setMediaSource(mediaSource)
+        exoPlayer?.prepare()
+        exoPlayer?.playWhenReady = wasPlaying
+        tsSeekAdapter?.notifySeekApplied(newPositionOffsetMs)
+        // シーク中ずっと再生中だった場合のみ、確定後にコントロールオーバーレイを閉じる
+        // (戻るボタン押下時と同じhideControlsOverlay()。一時停止中にシークしていた場合は
+        // ブラウズ中とみなしオーバーレイを表示したままにする)
+        if (wasPlaying) {
+            hideControlsOverlay(true)
+        }
     }
 
     private fun startHlsPlayback(actionId: Long, httpClient: OkHttpClient, mode: Int) {
@@ -417,13 +579,18 @@ class PlaybackVideoFragment : VideoSupportFragment() {
     }
 
     private fun setupCaptionListeners(tsFactory: TsReadexDataSource.Factory) {
-        captionHandle = AribCaptionFilter.create(1920, 1080, AribCaptionFilter.TYPE_CAPTION)
-        superimposeHandle = AribCaptionFilter.create(1920, 1080, AribCaptionFilter.TYPE_SUPERIMPOSE)
+        // シーク(MediaSource再構築)のたびに呼ばれるため、ハンドルは使い回す
+        if (captionHandle == 0L) {
+            captionHandle = AribCaptionFilter.create(1920, 1080, AribCaptionFilter.TYPE_CAPTION)
+        }
+        if (superimposeHandle == 0L) {
+            superimposeHandle = AribCaptionFilter.create(1920, 1080, AribCaptionFilter.TYPE_SUPERIMPOSE)
+        }
 
         tsFactory.captionPesListener = PesCallback { ptsMs, pesPayload ->
-            mainHandler.post {
+            postCaptionCallback {
                 val h = captionHandle
-                if (h == 0L || !captionEnabled) return@post
+                if (h == 0L || !captionEnabled) return@postCaptionCallback
                 if (AribCaptionFilter.decode(h, ptsMs, pesPayload, 0, pesPayload.size)) {
                     scheduleWithBufferDelay { scheduleCaptionRender(ptsMs) }
                 }
@@ -431,14 +598,19 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         }
 
         tsFactory.superimposePesListener = PesCallback { ptsMs, pesPayload ->
-            mainHandler.post {
+            postCaptionCallback {
                 val h = superimposeHandle
-                if (h == 0L || !superimposeEnabled) return@post
+                if (h == 0L || !superimposeEnabled) return@postCaptionCallback
                 if (AribCaptionFilter.decode(h, ptsMs, pesPayload, 0, pesPayload.size)) {
                     scheduleWithBufferDelay { scheduleSuperimposeRender(ptsMs) }
                 }
             }
         }
+    }
+
+    /** 字幕関連のHandlerコールバックをcaptionCallbackToken付きで投函する(シーク時に選択的キャンセルするため)。 */
+    private fun postCaptionCallback(delayMs: Long = 0L, action: () -> Unit) {
+        mainHandler.postAtTime(action, captionCallbackToken, SystemClock.uptimeMillis() + delayMs)
     }
 
     private fun scheduleWithBufferDelay(action: () -> Unit) {
@@ -447,7 +619,7 @@ class PlaybackVideoFragment : VideoSupportFragment() {
             (p.bufferedPosition - p.currentPosition).coerceAtLeast(0)
         } else 0L
         if (delayMs > 50) {
-            mainHandler.postDelayed(action, delayMs)
+            postCaptionCallback(delayMs, action)
         } else {
             action()
         }
@@ -654,6 +826,7 @@ class PlaybackVideoFragment : VideoSupportFragment() {
             hlsStreamId = null
         }
         mainHandler.removeCallbacksAndMessages(null)
+        tsProbeExecutor.shutdownNow()
         overlayView?.clearAll()
         destroyAribSessions()
         exoPlayer?.release()
@@ -670,6 +843,14 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         private const val TAG = "PlaybackVideoFragment"
         private const val UPDATE_PERIOD_MS = 200
         private const val KEEP_ALIVE_INTERVAL_MS = 10_000L
+        // 録画TSシークバーの目標刻み間隔。実測durationからこの間隔に収まるよう
+        // getSeekPositions()の点数を逆算する(各点は起動時にプローブ済みではなく、
+        // duration/head/tailからの計算のみで求める——シーク確定時に1点だけ補正する)。
+        private const val SEEK_POINT_INTERVAL_MS = 15_000L
+        // シーク点数(=getSeekPositions()の配列長)の安全上限。点数自体はプロービング
+        // コストを伴わないが、配列が際限なく肥大化しないための歯止め。
+        // これを超える長さの録画は刻み間隔がSEEK_POINT_INTERVAL_MSより広がる。
+        private const val SEEK_POINT_COUNT_MAX = 400
         // ライブHLSウォームアップ中のリトライ回数・間隔（20回 x 2秒 = 最大40秒程度待つ）
         private const val LIVE_WARMUP_RETRY_COUNT = 20
         private const val LIVE_WARMUP_RETRY_DELAY_MS = 2_000L
@@ -732,7 +913,9 @@ class PlaybackVideoFragment : VideoSupportFragment() {
     class MyPlaybackTransportControlGlue(
         context: Context?,
         impl: PlayerAdapter,
-        private val isTsContent: Boolean,
+        // ARIB字幕/デュアルモノ副音声のUI(CC/SI/音声切替ボタン)を出すかどうか。
+        // TSかどうかではなく、tsreadexネイティブ処理を実際に使っているかで決める。
+        private val useNativeTsProcessing: Boolean,
         private val isLive: Boolean,
         captionEnabled: Boolean,
         superimposeEnabled: Boolean,
@@ -786,7 +969,7 @@ class PlaybackVideoFragment : VideoSupportFragment() {
 
         override fun onCreatePrimaryActions(primaryActionsAdapter: ArrayObjectAdapter) {
             super.onCreatePrimaryActions(primaryActionsAdapter)
-            if (isTsContent) {
+            if (useNativeTsProcessing) {
                 primaryActionsAdapter.add(ccAction)
                 primaryActionsAdapter.add(superimposeAction)
                 primaryActionsAdapter.add(audioAction)
@@ -795,7 +978,7 @@ class PlaybackVideoFragment : VideoSupportFragment() {
                 primaryActionsAdapter.add(recordAction)
                 primaryActionsAdapter.add(infoAction)
             }
-            if (isTsContent || isLive) {
+            if (useNativeTsProcessing || isLive) {
                 primaryActions = primaryActionsAdapter
             }
         }

--- a/app/src/main/java/com/daigorian/epcltvapp/TsProbe.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/TsProbe.kt
@@ -1,0 +1,308 @@
+package com.daigorian.epcltvapp
+
+import android.util.Log
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+
+private const val TAG = "TsProbe"
+private const val TS_PACKET_SIZE = 188
+private const val SYNC_BYTE = 0x47.toByte()
+private const val PAT_PID = 0x0000
+
+/**
+ * 収録済みTSのシーク用軽量プロービング実装。
+ *
+ * TsReadexDataSource はフィルタ通過後の出力に対して固定PIDを前提にしているが、
+ * ここではフィルタを経由しない生の放送TSを直接HTTP Rangeで読み、PAT→PMTから
+ * PCR PIDを特定してPCRの時刻を追跡する（VLCのmodules/demux/mpeg/ts.cのProbeStart/
+ * ProbeEndに倣う）。全体を読むことはせず、ファイルの一部だけを読んで完結させる。
+ *
+ * シーク自体は都度の二分探索ではなく、head/tailの2点だけからLeanbackのシークUI
+ * (PlaybackSeekDataProvider経由)をすぐ有効化し、シーク確定時に [refineSeekPoint] で
+ * 1回だけ軽量プローブして補正する方式を使う。詳細はTsSeekDataProvider/
+ * PlaybackVideoFragmentを参照。
+ */
+object TsProbe {
+
+    /** PCRの時刻(ms)とそれが見つかった絶対バイト位置。 */
+    data class TimePoint(val timeMs: Long, val byteOffset: Long)
+
+    data class HeadProbeResult(val pcrPid: Int, val firstPcr: TimePoint)
+
+    private const val HEAD_PROBE_INITIAL_BYTES = 256 * 1024L
+    private const val HEAD_PROBE_MAX_BYTES = 3 * 1024 * 1024L
+    private const val PCR_SCAN_INITIAL_BYTES = 256 * 1024L
+    private const val PCR_SCAN_MAX_BYTES = 3 * 1024 * 1024L
+
+    /**
+     * 実際のファイルサイズをHEADリクエストで取得する。
+     * EPGStationのDBメタデータ(VideoFile.size等)は録画がエラー等で途中終了した場合に
+     * 実データとずれることがあるため使わず、常にサーバーへ問い合わせる。
+     */
+    fun fetchFileSize(url: String, client: OkHttpClient): Long? {
+        val request = Request.Builder().url(url).head().build()
+        return try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "fetchFileSize failed: code=${response.code}")
+                    return null
+                }
+                response.header("Content-Length")?.toLongOrNull()
+            }
+        } catch (e: IOException) {
+            Log.w(TAG, "fetchFileSize IOException: ${e.message}")
+            null
+        }
+    }
+
+    /** ファイル先頭を走査し、PCR PIDの特定と最初のPCR時刻取得を行う。 */
+    fun probeHead(url: String, client: OkHttpClient): HeadProbeResult? {
+        var scanBytes = HEAD_PROBE_INITIAL_BYTES
+        while (scanBytes <= HEAD_PROBE_MAX_BYTES) {
+            val bytes = readRange(url, client, 0, scanBytes) ?: return null
+            val syncOffset = findSyncOffset(bytes)
+            if (syncOffset >= 0) {
+                val pmtPid = findPmtPid(bytes, syncOffset)
+                if (pmtPid != null) {
+                    val pcrPid = findPcrPidFromPmt(bytes, syncOffset, pmtPid)
+                    if (pcrPid != null) {
+                        val firstPcr = scanForFirstPcr(bytes, syncOffset, 0L, pcrPid)
+                        if (firstPcr != null) {
+                            return HeadProbeResult(pcrPid, firstPcr)
+                        }
+                    }
+                }
+            }
+            if (bytes.size.toLong() < scanBytes) break // ファイル自体がscanBytesより小さい
+            scanBytes *= 2
+        }
+        Log.w(TAG, "probeHead: failed to resolve PAT/PMT/PCR within ${HEAD_PROBE_MAX_BYTES} bytes")
+        return null
+    }
+
+    /** ファイル末尾を走査し、既知のPCR PIDについて最後に見つかるPCRの時刻とバイト位置を返す。 */
+    fun probeTail(url: String, client: OkHttpClient, fileSize: Long, pcrPid: Int): TimePoint? {
+        var scanBytes = PCR_SCAN_INITIAL_BYTES
+        while (scanBytes <= PCR_SCAN_MAX_BYTES) {
+            val start = maxOf(0L, fileSize - scanBytes)
+            val bytes = readRange(url, client, start, fileSize - start) ?: return null
+            val syncOffset = findSyncOffset(bytes)
+            if (syncOffset >= 0) {
+                val result = scanForLastPcr(bytes, syncOffset, start, pcrPid)
+                if (result != null) return result
+            }
+            if (start == 0L) break
+            scanBytes *= 2
+        }
+        Log.w(TAG, "probeTail: failed to find PCR for pid=$pcrPid within ${PCR_SCAN_MAX_BYTES} bytes of EOF")
+        return null
+    }
+
+    /**
+     * 概算バイト位置(TsSeekDataProvider.estimateByteOffset等で求めた線形補間値)の近傍を
+     * 単発プローブし、実際のPCR時刻とバイト位置を返す。シーク確定時に1回だけ呼ばれる想定
+     * (二分探索のような繰り返しは行わない)。
+     */
+    fun refineSeekPoint(url: String, client: OkHttpClient, fileSize: Long, pcrPid: Int, guessByteOffset: Long): TimePoint? {
+        val aligned = guessByteOffset.coerceIn(0, (fileSize - TS_PACKET_SIZE).coerceAtLeast(0))
+        return readPcrNear(url, client, aligned, fileSize, pcrPid)
+    }
+
+    // ---- 内部実装 ----
+
+    private fun readPcrNear(url: String, client: OkHttpClient, startByte: Long, fileSize: Long, pcrPid: Int): TimePoint? {
+        var scanBytes = PCR_SCAN_INITIAL_BYTES
+        while (scanBytes <= PCR_SCAN_MAX_BYTES) {
+            val len = minOf(scanBytes, fileSize - startByte)
+            if (len <= 0) return null
+            val bytes = readRange(url, client, startByte, len) ?: return null
+            val syncOffset = findSyncOffset(bytes)
+            if (syncOffset >= 0) {
+                val result = scanForFirstPcr(bytes, syncOffset, startByte, pcrPid)
+                if (result != null) return result
+            }
+            if (startByte + scanBytes >= fileSize) break
+            scanBytes *= 2
+        }
+        return null
+    }
+
+    private fun readRange(url: String, client: OkHttpClient, start: Long, length: Long): ByteArray? {
+        if (length <= 0) return null
+        val end = start + length - 1
+        val request = Request.Builder().url(url).header("Range", "bytes=$start-$end").build()
+        return try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "readRange failed: code=${response.code} range=$start-$end")
+                    return null
+                }
+                response.body?.bytes()
+            }
+        } catch (e: IOException) {
+            Log.w(TAG, "readRange IOException: ${e.message}")
+            null
+        }
+    }
+
+    /** バッファ内で連続3パケット分(可能な限り)0x47が一致する位置をTSパケット境界として返す。 */
+    private fun findSyncOffset(buf: ByteArray): Int {
+        if (buf.size < TS_PACKET_SIZE * 2) return -1
+        val maxStart = buf.size - TS_PACKET_SIZE * 2
+        for (i in 0..maxStart) {
+            if (buf[i] == SYNC_BYTE && buf[i + TS_PACKET_SIZE] == SYNC_BYTE) {
+                val thirdOffset = i + TS_PACKET_SIZE * 2
+                if (thirdOffset >= buf.size || buf[thirdOffset] == SYNC_BYTE) {
+                    return i
+                }
+            }
+        }
+        return -1
+    }
+
+    private inline fun scanPackets(
+        buf: ByteArray,
+        syncOffset: Int,
+        onPacket: (pid: Int, pusi: Boolean, packetStart: Int) -> Boolean,
+    ) {
+        var pos = syncOffset
+        while (pos + TS_PACKET_SIZE <= buf.size) {
+            if (buf[pos] == SYNC_BYTE) {
+                val pid = ((buf[pos + 1].toInt() and 0x1F) shl 8) or (buf[pos + 2].toInt() and 0xFF)
+                val pusi = (buf[pos + 1].toInt() and 0x40) != 0
+                if (!onPacket(pid, pusi, pos)) return
+            }
+            pos += TS_PACKET_SIZE
+        }
+    }
+
+    /** アダプテーションフィールドを考慮したペイロード範囲。ペイロードが無ければnull。 */
+    private fun payloadRange(buf: ByteArray, packetStart: Int): Pair<Int, Int>? {
+        val afc = (buf[packetStart + 3].toInt() shr 4) and 0x03
+        val hasPayload = (afc and 0x01) != 0
+        if (!hasPayload) return null
+        val afLen = if ((afc and 0x02) != 0) (buf[packetStart + 4].toInt() and 0xFF) + 1 else 0
+        val payloadStart = packetStart + 4 + afLen
+        val payloadEnd = packetStart + TS_PACKET_SIZE
+        if (payloadStart >= payloadEnd) return null
+        return payloadStart to (payloadEnd - payloadStart)
+    }
+
+    private fun findPmtPid(buf: ByteArray, syncOffset: Int): Int? {
+        val assembler = SectionAssembler()
+        var result: Int? = null
+        scanPackets(buf, syncOffset) { pid, pusi, packetStart ->
+            if (pid != PAT_PID) return@scanPackets true
+            val range = payloadRange(buf, packetStart) ?: return@scanPackets true
+            val section = assembler.feed(buf, range.first, range.second, pusi) ?: return@scanPackets true
+            result = parsePatFirstProgramPid(section)
+            result == null
+        }
+        return result
+    }
+
+    private fun findPcrPidFromPmt(buf: ByteArray, syncOffset: Int, pmtPid: Int): Int? {
+        val assembler = SectionAssembler()
+        var result: Int? = null
+        scanPackets(buf, syncOffset) { pid, pusi, packetStart ->
+            if (pid != pmtPid) return@scanPackets true
+            val range = payloadRange(buf, packetStart) ?: return@scanPackets true
+            val section = assembler.feed(buf, range.first, range.second, pusi) ?: return@scanPackets true
+            result = parsePmtPcrPid(section)
+            result == null
+        }
+        return result
+    }
+
+    private fun scanForFirstPcr(buf: ByteArray, syncOffset: Int, absoluteBase: Long, pcrPid: Int): TimePoint? {
+        var result: TimePoint? = null
+        scanPackets(buf, syncOffset) { pid, _, packetStart ->
+            if (pid != pcrPid) return@scanPackets true
+            val pcr90k = extractPcr(buf, packetStart) ?: return@scanPackets true
+            result = TimePoint(pcr90k / 90L, absoluteBase + packetStart)
+            false
+        }
+        return result
+    }
+
+    private fun scanForLastPcr(buf: ByteArray, syncOffset: Int, absoluteBase: Long, pcrPid: Int): TimePoint? {
+        var result: TimePoint? = null
+        scanPackets(buf, syncOffset) { pid, _, packetStart ->
+            if (pid == pcrPid) {
+                val pcr90k = extractPcr(buf, packetStart)
+                if (pcr90k != null) result = TimePoint(pcr90k / 90L, absoluteBase + packetStart)
+            }
+            true // 末尾に一番近いものを採用するため最後まで走査する
+        }
+        return result
+    }
+
+    /** adaptation_field中のPCR(90kHzベース、拡張分は誤差500ms許容の探索には不要なため無視)。 */
+    private fun extractPcr(buf: ByteArray, packetStart: Int): Long? {
+        val afc = (buf[packetStart + 3].toInt() shr 4) and 0x03
+        if ((afc and 0x02) == 0) return null
+        val afLen = buf[packetStart + 4].toInt() and 0xFF
+        if (afLen < 7) return null
+        val flags = buf[packetStart + 5].toInt() and 0xFF
+        if ((flags and 0x10) == 0) return null // PCR_flag
+        val b0 = buf[packetStart + 6].toLong() and 0xFF
+        val b1 = buf[packetStart + 7].toLong() and 0xFF
+        val b2 = buf[packetStart + 8].toLong() and 0xFF
+        val b3 = buf[packetStart + 9].toLong() and 0xFF
+        val b4 = buf[packetStart + 10].toLong() and 0xFF
+        return (b0 shl 25) or (b1 shl 17) or (b2 shl 9) or (b3 shl 1) or (b4 ushr 7)
+    }
+
+    private fun parsePatFirstProgramPid(section: ByteArray): Int? {
+        if (section.size < 8) return null
+        if ((section[0].toInt() and 0xFF) != 0x00) return null
+        var i = 8
+        while (i + 4 <= section.size - 4) { // 末尾4byteはCRC32
+            val programNumber = ((section[i].toInt() and 0xFF) shl 8) or (section[i + 1].toInt() and 0xFF)
+            val pid = ((section[i + 2].toInt() and 0x1F) shl 8) or (section[i + 3].toInt() and 0xFF)
+            if (programNumber != 0) return pid
+            i += 4
+        }
+        return null
+    }
+
+    private fun parsePmtPcrPid(section: ByteArray): Int? {
+        if (section.size < 10) return null
+        if ((section[0].toInt() and 0xFF) != 0x02) return null
+        val pcrPid = ((section[8].toInt() and 0x1F) shl 8) or (section[9].toInt() and 0xFF)
+        return if (pcrPid in 0..0x1FFE) pcrPid else null
+    }
+
+    /** PAT/PMTのセクションが複数TSパケットに跨る場合の再構成。 */
+    private class SectionAssembler {
+        private var buf = ByteArray(0)
+        private var expectedLen = -1
+
+        fun feed(src: ByteArray, offset: Int, length: Int, pusi: Boolean): ByteArray? {
+            var pos = offset
+            val end = offset + length
+            if (pusi) {
+                if (pos >= end) return null
+                val pointerField = src[pos].toInt() and 0xFF
+                pos += 1 + pointerField
+                if (pos >= end) {
+                    buf = ByteArray(0)
+                    expectedLen = -1
+                    return null
+                }
+                buf = src.copyOfRange(pos, end)
+                if (buf.size < 3) {
+                    expectedLen = -1
+                    return null
+                }
+                val sectionLength = ((buf[1].toInt() and 0x0F) shl 8) or (buf[2].toInt() and 0xFF)
+                expectedLen = 3 + sectionLength
+            } else {
+                if (expectedLen < 0) return null
+                buf += src.copyOfRange(pos, end)
+            }
+            return if (expectedLen in 1..buf.size) buf.copyOf(expectedLen) else null
+        }
+    }
+}

--- a/app/src/main/java/com/daigorian/epcltvapp/TsReadexDataSource.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/TsReadexDataSource.kt
@@ -24,7 +24,17 @@ internal fun interface PesCallback {
 }
 
 @UnstableApi
-internal class TsReadexDataSource(private val upstream: DataSource) : DataSource {
+internal class TsReadexDataSource(
+    private val upstream: DataSource,
+    // シーク時、既知のバイト位置から再生を再開するためのオフセット(TsProbeが確定した188アライン済み位置)。
+    // 通常再生時は0。
+    private val startByteOffset: Long = 0L,
+    // false の場合 tsreadex ネイティブフィルタ(ARIB字幕多重化・音声PTS補完)を一切呼ばず、
+    // upstream のバイト列をそのまま素通しする。「TSかどうか」と「ネイティブ処理を使うか」は
+    // 独立した設定であるため、シーク(startByteOffset)機能は nativeProcessingEnabled の値に
+    // かかわらず常に有効。C.LENGTH_UNSET を返す判断も両モード共通(常に自前でシークを制御するため)。
+    private val nativeProcessingEnabled: Boolean = true,
+) : DataSource {
 
     private var filterHandle: Long = 0
 
@@ -51,14 +61,21 @@ internal class TsReadexDataSource(private val upstream: DataSource) : DataSource
     }
 
     override fun open(dataSpec: DataSpec): Long {
-        filterHandle = TsReadexFilter.create(
-            programNumberOrIndex = -1,
-            audio1Mode = 1 + 4 + 8,
-            audio2Mode = 1 + 4,
-            captionMode = 1,
-            superimposeMode = 1,
-        )
-        Log.d(TAG, "open: filter handle=$filterHandle uri=${dataSpec.uri}")
+        if (nativeProcessingEnabled) {
+            filterHandle = TsReadexFilter.create(
+                programNumberOrIndex = -1,
+                audio1Mode = 1 + 4 + 8,
+                audio2Mode = 1 + 4,
+                captionMode = 1,
+                superimposeMode = 1,
+            )
+        }
+        val openSpec = if (startByteOffset > 0) {
+            dataSpec.buildUpon().setPosition(dataSpec.position + startByteOffset).build()
+        } else {
+            dataSpec
+        }
+        Log.d(TAG, "open: filter handle=$filterHandle uri=${openSpec.uri} position=${openSpec.position}")
         partialLen = 0
         outputBytes = EMPTY
         outputPos = 0
@@ -67,14 +84,19 @@ internal class TsReadexDataSource(private val upstream: DataSource) : DataSource
         lastAudioPtsMain = -1L
         lastAudioPtsSub = -1L
         ptsInjectionCount = 0
-        upstream.open(dataSpec)
-        // tsreadex は先頭からの逐次処理を前提とするため、ExoPlayer に
-        // ストリーム長不明と伝えて TsDurationReader のシーク試行を抑止する
+        upstream.open(openSpec)
+        // シークは TsProbe が構築したテーブル + startByteOffset で自前制御するため、
+        // ExoPlayer にはストリーム長不明と伝えて TsDurationReader 自身のシーク試行を
+        // 常に抑止する(nativeProcessingEnabled の値にかかわらず)。
         return C.LENGTH_UNSET.toLong()
     }
 
     override fun read(target: ByteArray, offset: Int, length: Int): Int {
         if (length == 0) return 0
+
+        if (!nativeProcessingEnabled) {
+            return upstream.read(target, offset, length)
+        }
 
         if (outputPos < outputBytes.size) {
             val toCopy = minOf(outputBytes.size - outputPos, length)
@@ -205,9 +227,11 @@ internal class TsReadexDataSource(private val upstream: DataSource) : DataSource
     class Factory(private val upstreamFactory: DataSource.Factory) : DataSource.Factory {
         var captionPesListener: PesCallback? = null
         var superimposePesListener: PesCallback? = null
+        var startByteOffset: Long = 0L
+        var nativeProcessingEnabled: Boolean = true
 
         override fun createDataSource(): DataSource =
-            TsReadexDataSource(upstreamFactory.createDataSource()).also {
+            TsReadexDataSource(upstreamFactory.createDataSource(), startByteOffset, nativeProcessingEnabled).also {
                 it.captionPesListener = captionPesListener
                 it.superimposePesListener = superimposePesListener
             }

--- a/app/src/main/java/com/daigorian/epcltvapp/TsReadexDataSource.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/TsReadexDataSource.kt
@@ -85,9 +85,11 @@ internal class TsReadexDataSource(
         lastAudioPtsSub = -1L
         ptsInjectionCount = 0
         upstream.open(openSpec)
-        // シークは TsProbe が構築したテーブル + startByteOffset で自前制御するため、
-        // ExoPlayer にはストリーム長不明と伝えて TsDurationReader 自身のシーク試行を
-        // 常に抑止する(nativeProcessingEnabled の値にかかわらず)。
+        // ExoPlayerは通常、再生開始前にduration/シーク可否をTsDurationReader等で
+        // 確定させようとするが、これは非常に遅く即座の再生開始を妨げる。そのため
+        // ストリーム長不明と伝えてこの処理自体を常に抑止し(nativeProcessingEnabled の
+        // 値にかかわらず)、シークはTsSeekDataProviderの概算＋startByteOffsetによる
+        // 疑似シーク(確定時に1回だけ補正プローブ)で自前制御する。
         return C.LENGTH_UNSET.toLong()
     }
 

--- a/app/src/main/java/com/daigorian/epcltvapp/TsSeekDataProvider.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/TsSeekDataProvider.kt
@@ -1,0 +1,61 @@
+package com.daigorian.epcltvapp
+
+import androidx.leanback.widget.PlaybackSeekDataProvider
+
+private const val TS_PACKET_SIZE = 188
+
+/**
+ * 先頭・末尾プロービング(head/tailの2点)だけを元にLeanbackのシークUIへシーク位置を提供する。
+ *
+ * 全区間を事前プローブしたテーブルは持たない——duration表示同様、head/tailの2点さえ
+ * 分かればシークをすぐ有効化できるため。各シーク位置に対応する正確なバイト位置は、
+ * head/tailの線形補間による概算([estimateByteOffset])のみで、実際の値は
+ * シーク確定時に [TsProbe.refineSeekPoint] で1回だけ軽量プローブして補正する
+ * (PlaybackVideoFragment.performTsSeek参照)。
+ */
+internal class TsSeekDataProvider(
+    val fileSize: Long,
+    val pcrPid: Int,
+    private val headPoint: TsProbe.TimePoint,
+    private val tailPoint: TsProbe.TimePoint,
+    pointIntervalMs: Long,
+    maxPointCount: Int,
+    private val onSeekGestureStarted: () -> Unit,
+) : PlaybackSeekDataProvider() {
+
+    /** head起点(0)の相対時刻(ms)。PlayerAdapterのduration/position系と同じ基準。 */
+    val durationMs: Long = tailPoint.timeMs - headPoint.timeMs
+
+    private val positions: LongArray = run {
+        val pointCount = ((durationMs / pointIntervalMs) + 1).toInt().coerceIn(2, maxPointCount)
+        LongArray(pointCount) { i -> durationMs * i / (pointCount - 1) }
+    }
+
+    /** ログ表示等、副作用([getSeekPositions]参照)を発生させずに点数だけ知りたい場合用。 */
+    val seekPositionCount: Int get() = positions.size
+
+    /**
+     * Leanback(PlaybackTransportRowPresenter.startSeek())は、この呼び出し1つ手前で
+     * SeekUiClient.onSeekStarted()経由のpause()を必ず発火させ、その直後にこのメソッドを
+     * 1回だけ呼ぶ(leanback-1.0.0全体でこのメソッドの呼び出し元はここだけ確認済み)。
+     * そのため実質「シークジェスチャー開始」の合図として使え、直前の自動pauseを打ち消す
+     * フックとして利用している。返す配列自体は副作用と無関係で変化しない。
+     * このメソッドをログ出力等シーク以外の目的で呼び出さないこと([seekPositionCount]を使う)。
+     */
+    override fun getSeekPositions(): LongArray {
+        onSeekGestureStarted()
+        return positions
+    }
+
+    /** head/tailのバイト位置からの線形補間による概算バイト位置(188アライン済み)。 */
+    fun estimateByteOffset(relativeTimeMs: Long): Long {
+        if (durationMs <= 0) return headPoint.byteOffset
+        val clamped = relativeTimeMs.coerceIn(0, durationMs)
+        val span = tailPoint.byteOffset - headPoint.byteOffset
+        val raw = headPoint.byteOffset + span * clamped / durationMs
+        return raw - (raw % TS_PACKET_SIZE)
+    }
+
+    /** TsProbeが返す絶対PCR時刻(ms)を、duration/position系と同じ基準(head起点の相対時刻)に変換する。 */
+    fun toRelativeMs(absolutePcrMs: Long): Long = absolutePcrMs - headPoint.timeMs
+}

--- a/app/src/main/java/com/daigorian/epcltvapp/TsSeekDataProvider.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/TsSeekDataProvider.kt
@@ -23,12 +23,21 @@ internal class TsSeekDataProvider(
     private val onSeekGestureStarted: () -> Unit,
 ) : PlaybackSeekDataProvider() {
 
-    /** head起点(0)の相対時刻(ms)。PlayerAdapterのduration/position系と同じ基準。 */
+    /** head起点(0)の相対時刻(ms)。PlayerAdapterのduration/position系と同じ基準。実測の総時間そのもの。 */
     val durationMs: Long = tailPoint.timeMs - headPoint.timeMs
 
+    /**
+     * 実際にシーク先として許容する時刻の上限。durationMsそのものへのシークを許すと、
+     * 着地点近傍(tailPoint.byteOffset付近)にはほぼ再生可能なデータが残っておらず、
+     * MediaSourceの準備が実質失敗してプレーヤーがSTATE_IDLEのまま復帰不能になる不具合が
+     * あったため、末尾からpointIntervalMs分の余裕を残す。真の終端までは通常再生で
+     * 到達させる想定(そちらはTsSeekPlayerAdapter.play()のSTATE_ENDED処理で対応)。
+     */
+    private val maxSeekableMs: Long = (durationMs - pointIntervalMs).coerceAtLeast(0)
+
     private val positions: LongArray = run {
-        val pointCount = ((durationMs / pointIntervalMs) + 1).toInt().coerceIn(2, maxPointCount)
-        LongArray(pointCount) { i -> durationMs * i / (pointCount - 1) }
+        val pointCount = ((maxSeekableMs / pointIntervalMs) + 1).toInt().coerceIn(2, maxPointCount)
+        LongArray(pointCount) { i -> maxSeekableMs * i / (pointCount - 1) }
     }
 
     /** ログ表示等、副作用([getSeekPositions]参照)を発生させずに点数だけ知りたい場合用。 */
@@ -47,10 +56,10 @@ internal class TsSeekDataProvider(
         return positions
     }
 
-    /** head/tailのバイト位置からの線形補間による概算バイト位置(188アライン済み)。 */
+    /** head/tailのバイト位置からの線形補間による概算バイト位置(188アライン済み)。maxSeekableMsを超えないようクランプする。 */
     fun estimateByteOffset(relativeTimeMs: Long): Long {
         if (durationMs <= 0) return headPoint.byteOffset
-        val clamped = relativeTimeMs.coerceIn(0, durationMs)
+        val clamped = relativeTimeMs.coerceIn(0, maxSeekableMs)
         val span = tailPoint.byteOffset - headPoint.byteOffset
         val raw = headPoint.byteOffset + span * clamped / durationMs
         return raw - (raw % TS_PACKET_SIZE)

--- a/app/src/main/java/com/daigorian/epcltvapp/TsSeekPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/TsSeekPlayerAdapter.kt
@@ -122,6 +122,15 @@ internal class TsSeekPlayerAdapter(
     }
 
     override fun play() {
+        if (player.playbackState == Player.STATE_ENDED) {
+            // 終端到達後の再生ボタンは「最初から再生」を期待される。ExoPlayer標準の
+            // Util.handlePlayButtonAction は STATE_ENDED 時に「現在開いている
+            // MediaSourceの先頭」へ戻すだけだが、この場合の「先頭」は直前のシーク開始点
+            // (毎回シークのたびにMediaSourceを作り直しているため)であり、
+            // ファイル本来の先頭ではない。そのため通常のシーク要求として扱う。
+            onSeekRequested(0L)
+            return
+        }
         if (Util.handlePlayButtonAction(player)) getCallback()?.onPlayStateChanged(this)
     }
 

--- a/app/src/main/java/com/daigorian/epcltvapp/TsSeekPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/TsSeekPlayerAdapter.kt
@@ -1,0 +1,230 @@
+package com.daigorian.epcltvapp
+
+import android.os.Handler
+import android.os.Looper
+import android.view.Surface
+import android.view.SurfaceHolder
+import androidx.leanback.media.PlaybackGlueHost
+import androidx.leanback.media.PlayerAdapter
+import androidx.leanback.media.SurfaceHolderGlueHost
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.common.util.Util
+import androidx.media3.exoplayer.ExoPlayer
+
+/**
+ * androidx.media3.ui.leanback.LeanbackPlayerAdapter は final のため継承できない。
+ * 収録済みTS再生では duration/position を ExoPlayer 自身の値ではなく、
+ * TsProbe で確定した実測値 + 疑似シーク時のオフセットで管理する必要があるため、
+ * 同等のロジックを持つアダプタをここで自前実装する。
+ *
+ * TsReadexDataSource は tsreadex の逐次処理前提のため常に C.LENGTH_UNSET/C.TIME_UNSET を
+ * 返す。そのため ExoPlayer 自身は「今開いているバイト範囲の先頭からの経過時間」しか
+ * 知らない。実際の再生位置は [positionOffsetMs]（疑似シークで着地した論理時刻）に
+ * ExoPlayer 側の経過時間を足したものになる。
+ */
+@UnstableApi
+internal class TsSeekPlayerAdapter(
+    private val player: ExoPlayer,
+    private val updatePeriodMs: Int,
+    private val onSeekRequested: (positionMs: Long) -> Unit,
+) : PlayerAdapter(), Runnable {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val playerListener = PlayerEventListener()
+
+    private var surfaceHolderGlueHost: SurfaceHolderGlueHost? = null
+    private var hasSurface = false
+    private var lastNotifiedPreparedState = false
+    private var wasPlayingBeforeLastPause = false
+
+    /** TsProbeで実測した総再生時間(ms)。未確定の間は-1(不明)。 */
+    var knownDurationMs: Long = -1L
+        private set
+
+    /** 疑似シークで着地した論理再生位置(ms)。ExoPlayer自身の再生位置に加算する。 */
+    var positionOffsetMs: Long = 0L
+        private set
+
+    /**
+     * シーク確定直後〜補正プローブ完了までの間の表示位置。
+     * 非nullの間は player.currentPosition を足さず、この値をそのまま表示に使う
+     * (この間はまだ古いMediaSourceが再生中で、player.currentPositionは
+     * 新しいpositionOffsetMsと組み合わせると値がずれるため)。
+     */
+    private var pendingSeekPositionMs: Long? = null
+
+    fun setKnownDuration(durationMs: Long) {
+        knownDurationMs = durationMs
+        getCallback()?.onDurationChanged(this)
+    }
+
+    /**
+     * シーク確定時に即座に呼び、補正プローブ(ネットワークI/O)の完了を待たず
+     * シークバー表示だけ先に概算位置へ追従させる。これを呼ばないと、シーク確定の
+     * 瞬間に通常ポーリングが再開して一瞬古い位置に巻き戻ってから正しい位置へ
+     * 進むという不自然な動きになる。
+     */
+    fun notifySeekPending(estimatedPositionMs: Long) {
+        pendingSeekPositionMs = estimatedPositionMs
+        val callback = getCallback() ?: return
+        callback.onCurrentPositionChanged(this)
+        callback.onBufferedPositionChanged(this)
+    }
+
+    /** 疑似シーク(MediaSource再構築)が完了した直後に呼び、論理位置を確定させる。 */
+    fun notifySeekApplied(newPositionOffsetMs: Long) {
+        pendingSeekPositionMs = null
+        positionOffsetMs = newPositionOffsetMs
+        val callback = getCallback() ?: return
+        callback.onCurrentPositionChanged(this)
+        callback.onBufferedPositionChanged(this)
+    }
+
+    override fun onAttachedToHost(host: PlaybackGlueHost) {
+        if (host is SurfaceHolderGlueHost) {
+            surfaceHolderGlueHost = host
+            host.setSurfaceHolderCallback(playerListener)
+        }
+        notifyStateChanged()
+        player.addListener(playerListener)
+    }
+
+    override fun onDetachedFromHost() {
+        player.removeListener(playerListener)
+        surfaceHolderGlueHost?.setSurfaceHolderCallback(null)
+        surfaceHolderGlueHost = null
+        hasSurface = false
+        val callback = getCallback() ?: return
+        callback.onBufferingStateChanged(this, false)
+        callback.onPlayStateChanged(this)
+        maybeNotifyPreparedStateChanged(callback)
+    }
+
+    override fun setProgressUpdatingEnabled(enable: Boolean) {
+        handler.removeCallbacks(this)
+        if (enable) handler.post(this)
+    }
+
+    override fun isPlaying(): Boolean = !Util.shouldShowPlayButton(player)
+
+    override fun getDuration(): Long = knownDurationMs
+
+    override fun getCurrentPosition(): Long {
+        pendingSeekPositionMs?.let { pending ->
+            return if (knownDurationMs >= 0) pending.coerceIn(0, knownDurationMs) else pending
+        }
+        if (player.playbackState == Player.STATE_IDLE) return -1
+        val position = positionOffsetMs + player.currentPosition
+        return if (knownDurationMs >= 0) position.coerceIn(0, knownDurationMs) else position
+    }
+
+    override fun play() {
+        if (Util.handlePlayButtonAction(player)) getCallback()?.onPlayStateChanged(this)
+    }
+
+    override fun pause() {
+        wasPlayingBeforeLastPause = isPlaying()
+        if (Util.handlePauseButtonAction(player)) getCallback()?.onPlayStateChanged(this)
+    }
+
+    /**
+     * Leanbackはシーク開始時に無条件でpause()を呼ぶ(PlaybackTransportControlGlue内の
+     * SeekUiClient.onSeekStarted、オーバーライド不可)。シークバーへの単なるフォーカス/移動を
+     * 「シークが実行された」と誤解させる悪いアフォーダンスになるため、
+     * (シーク開始直前に再生中だった場合のみ)即座に再開して再生を止めない。
+     * 呼び出し元は TsSeekDataProvider.getSeekPositions() 参照。
+     */
+    fun resumePlaybackIfWasPlaying() {
+        if (wasPlayingBeforeLastPause) play()
+    }
+
+    override fun seekTo(positionInMs: Long) {
+        onSeekRequested(positionInMs)
+    }
+
+    override fun getBufferedPosition(): Long {
+        pendingSeekPositionMs?.let { pending ->
+            return if (knownDurationMs >= 0) pending.coerceIn(0, knownDurationMs) else pending
+        }
+        val position = positionOffsetMs + player.bufferedPosition
+        return if (knownDurationMs >= 0) position.coerceIn(0, knownDurationMs) else position
+    }
+
+    override fun isPrepared(): Boolean =
+        player.playbackState != Player.STATE_IDLE && (surfaceHolderGlueHost == null || hasSurface)
+
+    override fun run() {
+        val callback = getCallback() ?: return
+        callback.onCurrentPositionChanged(this)
+        callback.onBufferedPositionChanged(this)
+        handler.postDelayed(this, updatePeriodMs.toLong())
+    }
+
+    private fun setVideoSurface(surface: Surface?) {
+        hasSurface = surface != null
+        player.setVideoSurface(surface)
+        getCallback()?.let { maybeNotifyPreparedStateChanged(it) }
+    }
+
+    private fun notifyStateChanged() {
+        val playbackState = player.playbackState
+        val callback = getCallback() ?: return
+        maybeNotifyPreparedStateChanged(callback)
+        callback.onPlayStateChanged(this)
+        callback.onBufferingStateChanged(this, playbackState == Player.STATE_BUFFERING)
+        if (playbackState == Player.STATE_ENDED) callback.onPlayCompleted(this)
+    }
+
+    private fun maybeNotifyPreparedStateChanged(callback: PlayerAdapter.Callback) {
+        val prepared = isPrepared()
+        if (lastNotifiedPreparedState != prepared) {
+            lastNotifiedPreparedState = prepared
+            callback.onPreparedStateChanged(this)
+        }
+    }
+
+    private inner class PlayerEventListener : Player.Listener, SurfaceHolder.Callback {
+
+        override fun surfaceCreated(holder: SurfaceHolder) {
+            setVideoSurface(holder.surface)
+        }
+
+        override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+            // Do nothing.
+        }
+
+        override fun surfaceDestroyed(holder: SurfaceHolder) {
+            setVideoSurface(null)
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            getCallback()?.onError(this@TsSeekPlayerAdapter, error.errorCode, error.message ?: "")
+        }
+
+        override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+            val callback = getCallback() ?: return
+            // duration は knownDurationMs 側で管理するため、ここでは position 系のみ再通知する。
+            callback.onCurrentPositionChanged(this@TsSeekPlayerAdapter)
+            callback.onBufferedPositionChanged(this@TsSeekPlayerAdapter)
+        }
+
+        override fun onPositionDiscontinuity(
+            oldPosition: Player.PositionInfo,
+            newPosition: Player.PositionInfo,
+            reason: Int,
+        ) {
+            val callback = getCallback() ?: return
+            callback.onCurrentPositionChanged(this@TsSeekPlayerAdapter)
+            callback.onBufferedPositionChanged(this@TsSeekPlayerAdapter)
+        }
+
+        override fun onEvents(player: Player, events: Player.Events) {
+            if (events.containsAny(Player.EVENT_PLAY_WHEN_READY_CHANGED, Player.EVENT_PLAYBACK_STATE_CHANGED)) {
+                notifyStateChanged()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要

- 収録済み・収録中を問わず、オリジナルTS再生時にシークができなかった問題を解消
  - 収録中番組は、既に書き込み済みの範囲内でのシークが可能になる（ライブ側で書き込まれ続けるファイルを継続して読み進める"追いかけ再生"自体は別問題。[#42](https://github.com/daig0rian/epcltvapp/issues/42) 参照）
- 根本原因: ExoPlayerは通常、再生開始前にduration/シーク可否を確定させる処理（TS内のPCRを探すため一部を読み込む）を行うが、これが非常に遅く再生開始を大きく妨げる。`TsReadexDataSource.open()`は`C.LENGTH_UNSET`を返してこの処理を無効化し、再生開始の速さを優先していた

## 設計

- **duration把握**: EPGStationのメタデータ（録画エラー等で実データと乖離しうる）は使わず、ファイル先頭・末尾を軽量プロービングして実測（`TsProbe.probeHead`/`probeTail`）
- **シーク方式**: `TsSeekDataProvider`（Leanbackの`PlaybackSeekDataProvider`実装）がhead/tailの2点のみを保持し、各シーク位置のバイト位置は線形補間で概算する。シーク確定時にのみ1回だけ軽量プローブ（`TsProbe.refineSeekPoint`）して実際のPCR時刻・バイト位置に補正する。二分探索のような都度サーバー往復を伴う方式は、D-pad連打時にコストが積み重なるため不採用
  - `PlaybackSeekDataProvider`設定時、Leanbackはシーク確定時に1回だけ`seekTo()`を呼ぶため、D-pad連打時の負荷も最小限
- **`isTsContent`と`useNativeTsProcessing`の分離**: 「TSファイルかどうか」と「tsreadexネイティブ処理(ARIB字幕/デュアルモノ副音声)を使うかどうか」を独立したフラグに分離。シーク機能はネイティブ処理設定に関係なく動作する
- **UX調整**:
  - シーク開始時にLeanbackが自動で一時停止する挙動を打ち消し、シーク中も再生を継続
  - シーク確定後、再生継続中ならコントロールオーバーレイを自動で閉じる
  - シーク時に前の字幕が残留する不具合を修正（Handlerコールバックのトークンベースキャンセル + `AribCaptionFilter.flush`）

## 対象外

- 収録中番組の"追いかけ再生": [#42](https://github.com/daig0rian/epcltvapp/issues/42)
- ライブ視聴（mpegts直送・HLS）、録画HLS視聴（変更なし）
- MP4等エンコード済み動画の再生（既存のExoPlayer標準経路のまま、影響なし）
- サムネイル付きシーク（Phase 2として計画中）

## テスト項目

- [x] 録画オリジナルTS再生でシークバーが機能する（duration表示・任意位置へのシーク）
- [x] 収録中番組のオリジナルTS再生でも、書き込み済み範囲内でシークが機能する
- [x] D-pad長押しでの連続シークが引っかからず滑らかに動く
- [x] シーク中も映像が止まらず再生継続する
- [x] シーク確定後にコントロールオーバーレイが自動で閉じる（再生中の場合）
- [x] 一時停止中にシークした場合は一時停止のままになる
- [x] シーク後、古い字幕が残留しない
- [x] ネイティブTS処理設定がOFFでも録画TSのシークが機能する（ARIB字幕は出ない）
- [x] MP4等エンコード済み動画の再生・シークに影響がない
- [x] ライブ視聴（mpegts直送・HLS）に影響がない

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>