### PR TITLE
エンコード済み動画・録画HLSのシーク時に再生が止まらないようにする

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/DurationSeekDataProvider.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/DurationSeekDataProvider.kt
@@ -1,0 +1,42 @@
+package com.daigorian.epcltvapp
+
+import androidx.leanback.widget.PlaybackSeekDataProvider
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+
+private const val SEEK_POINT_INTERVAL_MS = 15_000L
+private const val SEEK_POINT_COUNT_MAX = 400
+
+/**
+ * TS以外(エンコード済み直接再生・HLS)向けの汎用シークデータプロバイダ。
+ * TsSeekDataProviderと異なりバイトオフセットの概算は不要——ExoPlayerがdurationを
+ * ネイティブに把握しており、seekTo(ms)もそのまま使えるため、durationを均等割りした
+ * 位置をその場で返すだけでよい。
+ */
+@UnstableApi
+internal class DurationSeekDataProvider(
+    private val player: ExoPlayer,
+    private val onSeekGestureStarted: () -> Unit,
+) : PlaybackSeekDataProvider() {
+
+    /**
+     * Leanback(PlaybackTransportRowPresenter.startSeek())は、この呼び出し1つ手前で
+     * SeekUiClient.onSeekStarted()経由のpause()を必ず発火させ、その直後にこのメソッドを
+     * 1回だけ呼ぶ(TsSeekDataProvider.getSeekPositions()参照、leanback-1.0.0のソースで確認済み)。
+     * そのため実質「シークジェスチャー開始」の合図として使え、直前の自動pauseを打ち消す
+     * フックとして利用している。
+     */
+    override fun getSeekPositions(): LongArray {
+        onSeekGestureStarted()
+        val durationMs = player.duration
+        if (durationMs == C.TIME_UNSET || durationMs <= 0) {
+            // durationが未確定な間にシークジェスチャーが始まった場合の保険。
+            // 次にシークジェスチャーが始まる時点(=このメソッドが再度呼ばれる時点)には
+            // 大抵durationが確定しているため、再計算されて解消する。
+            return longArrayOf(player.currentPosition)
+        }
+        val pointCount = ((durationMs / SEEK_POINT_INTERVAL_MS) + 1).toInt().coerceIn(2, SEEK_POINT_COUNT_MAX)
+        return LongArray(pointCount) { i -> durationMs * i / (pointCount - 1) }
+    }
+}

--- a/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
@@ -36,7 +36,6 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
-import androidx.media3.ui.leanback.LeanbackPlayerAdapter
 import androidx.preference.PreferenceManager
 import com.daigorian.epcltvapp.epgstationcaller.EpgStation
 import com.daigorian.epcltvapp.epgstationcaller.GetRecordedResponse
@@ -90,6 +89,8 @@ class PlaybackVideoFragment : VideoSupportFragment() {
 
     // TS seek support (録画オリジナルTSのみ)
     private var tsSeekAdapter: TsSeekPlayerAdapter? = null
+    // TS以外(エンコード済み直接再生・HLS)のシーク対応
+    private var seekableAdapter: SeekableLeanbackPlayerAdapter? = null
     private var tsSeekUrl: String? = null
     private var tsSeekHttpClient: OkHttpClient? = null
     private var tsSeekDataProvider: TsSeekDataProvider? = null
@@ -249,7 +250,7 @@ class PlaybackVideoFragment : VideoSupportFragment() {
                 performTsSeek(targetMs)
             }.also { tsSeekAdapter = it }
         } else {
-            LeanbackPlayerAdapter(requireContext(), exoPlayer!!, UPDATE_PERIOD_MS)
+            SeekableLeanbackPlayerAdapter(requireContext(), exoPlayer!!, UPDATE_PERIOD_MS).also { seekableAdapter = it }
         }
         val glueHost = VideoSupportFragmentGlueHost(this@PlaybackVideoFragment)
 
@@ -259,6 +260,15 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         mTransportControlGlue.host = glueHost
         mTransportControlGlue.title = recordedProgram?.name ?: recordedItem?.name ?: liveChannelName
         mTransportControlGlue.subtitle = recordedProgram?.description ?: recordedItem?.description
+        // TS以外はExoPlayerがdurationをネイティブに把握しているため、TSのような事前プロービング
+        // 待ちなしで直接シークプロバイダを組める(ExoPlayerネイティブのseekTo(ms)がそのまま使える)。
+        // これによりLeanbackはDpadでのスクラブ中に実シークを都度呼ばず確定時に1回だけ呼ぶようになり、
+        // かつシーク開始時の自動pauseもTSと同様に打ち消せる(SeekableLeanbackPlayerAdapter参照)。
+        seekableAdapter?.let { adapter ->
+            mTransportControlGlue.setSeekProvider(
+                DurationSeekDataProvider(exoPlayer!!) { adapter.resumePlaybackIfWasPlaying() }
+            )
+        }
         // 録画オリジナルTSはシーク点テーブルの構築が終わるまでシーク不可にする
         // (テーブル未完成の間にシーク操作されると、Leanbackのデフォルトの1%刻み挙動＋
         // 都度のバイト位置探索という避けたかった経路に落ちてしまうため)。

--- a/app/src/main/java/com/daigorian/epcltvapp/SeekableLeanbackPlayerAdapter.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SeekableLeanbackPlayerAdapter.kt
@@ -1,0 +1,188 @@
+package com.daigorian.epcltvapp
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.view.Surface
+import android.view.SurfaceHolder
+import androidx.leanback.media.PlaybackGlueHost
+import androidx.leanback.media.PlayerAdapter
+import androidx.leanback.media.SurfaceHolderGlueHost
+import androidx.media3.common.C
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import androidx.media3.common.VideoSize
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.common.util.Util
+import androidx.media3.exoplayer.ExoPlayer
+
+/**
+ * androidx.media3.ui.leanback.LeanbackPlayerAdapter は final のため継承できず、
+ * Leanbackがシーク開始時に無条件で呼ぶ pause() を打ち消すフックを差し込めない
+ * (TsSeekPlayerAdapter参照。あちらはTS固有のバイトオフセット計算のために自前実装が
+ * 必要だったが、こちらはそれが理由の全て)。
+ * duration/position/seekTo等の挙動は本家LeanbackPlayerAdapter(media3-ui-leanback 1.3.1)と
+ * 同一のロジックをそのまま踏襲する。
+ */
+@UnstableApi
+internal class SeekableLeanbackPlayerAdapter(
+    private val context: Context,
+    private val player: ExoPlayer,
+    private val updatePeriodMs: Int,
+) : PlayerAdapter(), Runnable {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val playerListener = PlayerEventListener()
+
+    private var surfaceHolderGlueHost: SurfaceHolderGlueHost? = null
+    private var hasSurface = false
+    private var lastNotifiedPreparedState = false
+    private var wasPlayingBeforeLastPause = false
+
+    override fun onAttachedToHost(host: PlaybackGlueHost) {
+        if (host is SurfaceHolderGlueHost) {
+            surfaceHolderGlueHost = host
+            host.setSurfaceHolderCallback(playerListener)
+        }
+        notifyStateChanged()
+        player.addListener(playerListener)
+    }
+
+    override fun onDetachedFromHost() {
+        player.removeListener(playerListener)
+        surfaceHolderGlueHost?.setSurfaceHolderCallback(null)
+        surfaceHolderGlueHost = null
+        hasSurface = false
+        val callback = getCallback() ?: return
+        callback.onBufferingStateChanged(this, false)
+        callback.onPlayStateChanged(this)
+        maybeNotifyPreparedStateChanged(callback)
+    }
+
+    override fun setProgressUpdatingEnabled(enable: Boolean) {
+        handler.removeCallbacks(this)
+        if (enable) handler.post(this)
+    }
+
+    override fun isPlaying(): Boolean = !Util.shouldShowPlayButton(player)
+
+    override fun getDuration(): Long {
+        val durationMs = player.duration
+        return if (durationMs == C.TIME_UNSET) -1 else durationMs
+    }
+
+    override fun getCurrentPosition(): Long =
+        if (player.playbackState == Player.STATE_IDLE) -1 else player.currentPosition
+
+    override fun play() {
+        if (Util.handlePlayButtonAction(player)) getCallback()?.onPlayStateChanged(this)
+    }
+
+    override fun pause() {
+        wasPlayingBeforeLastPause = isPlaying()
+        if (Util.handlePauseButtonAction(player)) getCallback()?.onPlayStateChanged(this)
+    }
+
+    /**
+     * Leanbackはシーク開始時に無条件でpause()を呼ぶ(PlaybackTransportControlGlue内の
+     * SeekUiClient.onSeekStarted、オーバーライド不可)。シークバーへの単なるフォーカス/移動を
+     * 「シークが実行された」と誤解させる悪いアフォーダンスになるため、
+     * (シーク開始直前に再生中だった場合のみ)即座に再開して再生を止めない。
+     * 呼び出し元は DurationSeekDataProvider.getSeekPositions() 参照。
+     */
+    fun resumePlaybackIfWasPlaying() {
+        if (wasPlayingBeforeLastPause) play()
+    }
+
+    override fun seekTo(positionInMs: Long) {
+        player.seekTo(player.currentMediaItemIndex, positionInMs)
+    }
+
+    override fun getBufferedPosition(): Long = player.bufferedPosition
+
+    override fun isPrepared(): Boolean =
+        player.playbackState != Player.STATE_IDLE && (surfaceHolderGlueHost == null || hasSurface)
+
+    override fun run() {
+        val callback = getCallback() ?: return
+        callback.onCurrentPositionChanged(this)
+        callback.onBufferedPositionChanged(this)
+        handler.postDelayed(this, updatePeriodMs.toLong())
+    }
+
+    private fun setVideoSurface(surface: Surface?) {
+        hasSurface = surface != null
+        player.setVideoSurface(surface)
+        getCallback()?.let { maybeNotifyPreparedStateChanged(it) }
+    }
+
+    private fun notifyStateChanged() {
+        val playbackState = player.playbackState
+        val callback = getCallback() ?: return
+        maybeNotifyPreparedStateChanged(callback)
+        callback.onPlayStateChanged(this)
+        callback.onBufferingStateChanged(this, playbackState == Player.STATE_BUFFERING)
+        if (playbackState == Player.STATE_ENDED) callback.onPlayCompleted(this)
+    }
+
+    private fun maybeNotifyPreparedStateChanged(callback: PlayerAdapter.Callback) {
+        val prepared = isPrepared()
+        if (lastNotifiedPreparedState != prepared) {
+            lastNotifiedPreparedState = prepared
+            callback.onPreparedStateChanged(this)
+        }
+    }
+
+    private inner class PlayerEventListener : Player.Listener, SurfaceHolder.Callback {
+
+        override fun surfaceCreated(holder: SurfaceHolder) {
+            setVideoSurface(holder.surface)
+        }
+
+        override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+            // Do nothing.
+        }
+
+        override fun surfaceDestroyed(holder: SurfaceHolder) {
+            setVideoSurface(null)
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            getCallback()?.onError(
+                this@SeekableLeanbackPlayerAdapter,
+                error.errorCode,
+                context.getString(androidx.leanback.R.string.lb_media_player_error, error.errorCode, 0)
+            )
+        }
+
+        override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+            val callback = getCallback() ?: return
+            callback.onDurationChanged(this@SeekableLeanbackPlayerAdapter)
+            callback.onCurrentPositionChanged(this@SeekableLeanbackPlayerAdapter)
+            callback.onBufferedPositionChanged(this@SeekableLeanbackPlayerAdapter)
+        }
+
+        override fun onPositionDiscontinuity(
+            oldPosition: Player.PositionInfo,
+            newPosition: Player.PositionInfo,
+            reason: Int,
+        ) {
+            val callback = getCallback() ?: return
+            callback.onCurrentPositionChanged(this@SeekableLeanbackPlayerAdapter)
+            callback.onBufferedPositionChanged(this@SeekableLeanbackPlayerAdapter)
+        }
+
+        override fun onVideoSizeChanged(videoSize: VideoSize) {
+            if (videoSize.width == 0 || videoSize.height == 0) return
+            val scaledWidth = Math.round(videoSize.width * videoSize.pixelWidthHeightRatio)
+            getCallback()?.onVideoSizeChanged(this@SeekableLeanbackPlayerAdapter, scaledWidth, videoSize.height)
+        }
+
+        override fun onEvents(player: Player, events: Player.Events) {
+            if (events.containsAny(Player.EVENT_PLAY_WHEN_READY_CHANGED, Player.EVENT_PLAYBACK_STATE_CHANGED)) {
+                notifyStateChanged()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- TSモードのシーク(スクラブ中も再生継続・確定時に1回だけ実シーク)と同じ挙動を、エンコード済み動画・録画HLSの再生にも適用した。
- `SeekableLeanbackPlayerAdapter`: `androidx.media3.ui.leanback.LeanbackPlayerAdapter`(final)相当の自前実装。シーク開始時にLeanbackが必ず呼ぶ`pause()`を打ち消すフックを追加。
- `DurationSeekDataProvider`: `TsSeekDataProvider`の非TS版。ExoPlayerのdurationから均等割りした位置を返すだけで、バイトオフセット計算は不要。

## Test plan
- [x] エンコード済み動画・録画HLSでシークバー操作中に再生が止まらないこと
- [x] Dpad連打で次々にシークがかからず、確定時に1回だけ効くこと
- [x] TS再生・ライブ再生にregressionがないこと