### PR TITLE
デフォルトの再生プレーヤーを内蔵プレーヤーに変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Kotlin 製 Android TV アプリ (Leanback UI フレームワーク使用)。
 - **UI:** Leanback (Android TV) ※将来的に Compose for TV への移行を計画
 - **ネットワーク:** Retrofit2 + Gson
 - **画像:** Glide
-- **動画再生:** libVLC (内蔵) + 外部プレーヤー対応 (MX Player / VLC)
+- **動画再生:** ExoPlayer (media3) + Leanback (`androidx.media3:media3-ui-leanback`) による内蔵プレーヤー + 外部プレーヤー対応 (MX Player / VLC)
 - **最小 SDK:** API 22 (Android 5.1)
 - **コンパイル SDK:** API 34 (Android 14)
 - **ターゲット SDK:** API 34 (Android 14)
@@ -50,9 +50,13 @@ Kotlin 製 Android TV アプリ (Leanback UI フレームワーク使用)。
 | 項目 | 状況 | 理由 |
 |------|------|------|
 | `SettingsFragment.kt` の `PreferenceFragment` | 警告あり・保留中 | `leanback-preference` stable 1.1.0 が存在しない。Leanback 自体が deprecated のため今後は Compose for TV への移行で解消予定 |
-| H.264 エンコード済み動画の1:1描画・緑フチ問題 | 未解決・保留中 | 下記「既知の未解決バグ」を参照 |
 
-## 既知の未解決バグ
+## 過去の既知バグ（libVLC内蔵プレーヤー時代・現在は非該当）
+
+> **注記:** 以下は内蔵プレーヤーが libVLC ベースだった当時の記録。その後 ExoPlayer (media3) +
+> Leanback ベースの内蔵プレーヤーに移行しており、libVLC 関連の依存関係・クラスは現在の
+> コードベースに存在しない。この問題が現行の内蔵プレーヤーにも当てはまるかは未検証。
+> 経緯の記録として残す。
 
 ### H.264 エンコード済み動画が1:1描画される（緑フチ問題）
 

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -25,10 +25,10 @@
     <string name="movie_player">録画を再生するプレーヤー</string>
     <string name="please_install_external_player">外部プレーヤーをインストールしてください</string>
     <string name="port_number_of_epgstation">EPGStation の PORT番号</string>
-    <string name="pref_options_movie_player_label_MX">MX Player (デフォルト)</string>
+    <string name="pref_options_movie_player_label_MX">MX Player</string>
     <string name="pref_options_movie_player_label_MX_PRO">MX Player Pro</string>
     <string name="pref_options_movie_player_label_VLC">VLC</string>
-    <string name="pref_options_movie_player_label_INTERNAL">内蔵</string>
+    <string name="pref_options_movie_player_label_INTERNAL">内蔵 (デフォルト)</string>
     <string name="settings_title">設定</string>
     <string name="not_a_valid_ipv4_addr">%1$s は有効なIPv4アドレスではありません</string>
     <string name="not_a_valid_port_num">%1$s は有効なポート番号ではありません</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,14 +36,14 @@
     <string name="pref_key_port_num"               translatable="false">KEY_PORT_NUM</string>
     <string name="pref_val_port_num_default"       translatable="false">8888</string>
     <string name="pref_key_player"                 translatable="false">KEY_PLAYER</string>
-    <string name="pref_val_player_default"         translatable="false">@string/pref_options_movie_player_val_MX</string>
+    <string name="pref_val_player_default"         translatable="false">@string/pref_options_movie_player_val_INTERNAL</string>
     <string name="pref_key_num_of_history"         translatable="false">KEY_NUM_OF_HISTORY</string>
     <string name="pref_val_num_of_history_default" translatable="false">@string/pref_options_num_of_history_val_3</string>
 
-    <string name="pref_options_movie_player_label_MX">MX Player (Default)</string>
+    <string name="pref_options_movie_player_label_MX">MX Player</string>
     <string name="pref_options_movie_player_label_MX_PRO">MX Player Pro</string>
     <string name="pref_options_movie_player_label_VLC">VLC</string>
-    <string name="pref_options_movie_player_label_INTERNAL">Internal</string>
+    <string name="pref_options_movie_player_label_INTERNAL">Internal (Default)</string>
 
     <string-array name="pref_options_movie_player_label" >
         <item>@string/pref_options_movie_player_label_MX</item>


### PR DESCRIPTION
## Summary
- シークUXのTS/非TSパリティ(#50)が入り内蔵プレーヤーの挙動が一通り整ったため、初回起動時のデフォルト再生プレーヤーをMX Playerから内蔵(Internal)に変更した。
- 調査の過程でCLAUDE.mdの技術スタック表・既知バグ記載がlibVLC時代のまま更新漏れになっていたのを発見したため、ExoPlayer(media3)+Leanbackの現状に合わせて修正した(libVLC固有の緑フチ問題は過去の記録として注記付きで残した)。

## Test plan
- [x] 新規インストール相当(設定画面で内蔵プレーヤーを選択)でプレーヤー選択が反映されること
- [x] 既存インストールでは自動的に変更されず、設定画面から手動切り替えできること