### PR TITLE
環境変数がないローカルでもリリースビルドを署名できるようにする

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,10 +37,13 @@ android {
 
     signingConfigs {
         release {
-            storeFile     file(System.getenv("RELEASE_KEYSTORE_PATH") ?: "dummy.jks")
-            storePassword System.getenv("RELEASE_STORE_PASSWORD") ?: ""
-            keyAlias      System.getenv("RELEASE_KEY_ALIAS")       ?: ""
-            keyPassword   System.getenv("RELEASE_KEY_PASSWORD")    ?: ""
+            // CI(GitHub Actions)は RELEASE_KEYSTORE_* を環境変数で渡す(release.yml)。
+            // 環境変数がないローカルでは debug と同じ鍵にフォールバックする。性能計測などで
+            // リリースビルド(非debuggable)を手元で動かすためのもので、配布物には使えない。
+            storeFile     file(System.getenv("RELEASE_KEYSTORE_PATH") ?: signingConfigs.debug.storeFile)
+            storePassword System.getenv("RELEASE_STORE_PASSWORD")     ?: signingConfigs.debug.storePassword
+            keyAlias      System.getenv("RELEASE_KEY_ALIAS")          ?: signingConfigs.debug.keyAlias
+            keyPassword   System.getenv("RELEASE_KEY_PASSWORD")       ?: signingConfigs.debug.keyPassword
         }
     }
 


### PR DESCRIPTION
リリース署名の環境変数は CI が渡すため、ローカルで `assembleRelease` すると存在しない
`dummy.jks` を参照してビルドが失敗していた。環境変数がないときは debug 署名設定と同じ鍵に
フォールバックさせる。

非 debuggable なビルドを手元で動かして挙動を確かめられるようにするのが目的
（#76 の計測で使用）。こうして作った APK は配布には使えない。

CI は `release.yml` が必ず `RELEASE_KEYSTORE_PATH` を渡すため、フォールバックには入らない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)