### PR TITLE
字幕を抽出時パースに切り替える (Issue #69 の検証)

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
@@ -59,6 +59,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.ui.CaptionStyleCompat
 import androidx.media3.ui.SubtitleView
@@ -1119,7 +1120,21 @@ class PlaybackVideoFragment : VideoSupportFragment() {
             ProgressiveMediaSource.Factory(tsFactory)
                 .createMediaSource(MediaItem.fromUri(url))
         } else {
-            ProgressiveMediaSource.Factory(dataSourceFactory)
+            // 字幕を「描画時パース」ではなく「抽出時パース」で処理する(Issue #69 の検証)。
+            // 旧経路は TextRenderer がデコーダのバッファ受け渡しを介してCueを1件ずつ送り出す
+            // ため、実機では映像・音声・メインスレッド・バッファのいずれも正常なまま字幕の
+            // 更新だけが数秒止まり、その後まとめて届く現象が観測されている。新経路は
+            // 抽出時にCueへ変換して再生位置から直接決めるので、この経路自体が存在しない。
+            //
+            // TS には適用しない。androidx/media#1621 で「抽出時パースにするとTSの映像が
+            // ブロックノイズだらけになる」報告があり、再現機種の傾向(Android 7〜11の
+            // TV系端末)がこのアプリの対象と重なるため。
+            //
+            // media3 1.4.0 ではこれが既定になる。新経路の実装は1.3.1と1.4.0で同一なので、
+            // バージョンは上げずにここだけ切り替えて検証する。
+            val extractorsFactory = DefaultExtractorsFactory()
+                .experimentalSetTextTrackTranscodingEnabled(true)
+            ProgressiveMediaSource.Factory(dataSourceFactory, extractorsFactory)
                 .createMediaSource(MediaItem.fromUri(url))
         }
         exoPlayer?.setMediaSource(mediaSource)


### PR DESCRIPTION
## 変更内容

エンコード済み動画の字幕処理を、旧経路(描画時パース)から新経路(抽出時パース)へ切り替える。
`ProgressiveMediaSource.Factory` に `experimentalSetTextTrackTranscodingEnabled(true)` を設定した
`DefaultExtractorsFactory` を渡すだけで、実質2行。

**TS には適用しない。** androidx/media#1621 で「抽出時パースにすると TS の映像がブロックノイズ
だらけになる」報告があり、再現機種の傾向(Android 7〜11 の TV 系端末)がこのアプリの対象と重なるため。

media3 1.4.0 ではこれが既定になる。新経路の実装は 1.3.1 と 1.4.0 で同一(ソース差分で確認済み)なので、
バージョンは上げずにここだけ切り替える。

## これは検証であって、まだ結論ではない

Refs #69

Issue #69 の「エンコード済み動画で字幕の更新だけが数秒〜数十秒止まる」現象に対する**仮説の検証**。
常設計測で原因を旧経路に絞り込んだ段階であり、この変更で直るかどうかは**これから確かめる**。

発生頻度が低く(30分に1回あるかないか)、再現待ちに数時間〜数日かかるため、検証そのものを
日常の視聴で回せるよう master に取り込む。**マージはこの件の解決を意味しない。**

### 判定方法

常設計測(`SubtitleStallDiagnostics`)の `LATE_CUE` 件数で客観的に判定する。

| | |
|---|---|
| 切り替え前の基準 | 約7.5時間の視聴で `LATE_CUE` **9件**(遅れ 1.7〜10.5秒) |
| 期待する結果 | 同程度の視聴時間で **0件** |
| 0件にならなかった場合 | 旧経路は原因ではなかったと判定し、判定表(メインスレッド/描画/供給)に戻って切り分けを続ける |

経過は Issue #69 に記録する。**結論が出るまで Issue は閉じない。**

## テスト項目

- [x] エンコード済み動画で字幕がこれまでどおり表示される(スタイル・位置・ON/OFF)
- [x] 録画オリジナルTS の ARIB 字幕が従来どおり(androidx/media#1621 の予防的確認)
- [x] ライブ視聴が従来どおり
- [x] シーク後に字幕が正しく復帰する
- [x] シリーズ連続再生で次の回に移っても字幕が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)
