### PR TITLE
字幕計測でバックグラウンド復帰を停止と誤検知しないようにする

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/SubtitleStallDiagnostics.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/SubtitleStallDiagnostics.kt
@@ -26,7 +26,8 @@ import androidx.media3.ui.SubtitleView
  * 空サンプル表示中なら「しばらく字幕が出ない」という、見え方の違う2つの症状が同じ原因から出る。
  * どこで止まったのかは、Cueが届く経路を分解して同時に記録しないと切り分けられない。
  *
- *  - `BEAT`  … メインスレッドが動いているか。250ms周期で叩き、実測間隔の最大値を出す。
+ *  - `BEAT`  … メインスレッドが動いているか。250ms周期で叩き、実測間隔の最大値を出す
+ *              (再生中のみ計上する。理由は [beat] のコメント参照)。
  *  - `CUE`   … Cueの到着。`lag` はそのCue自身の時刻から何ms遅れて届いたか。
  *  - `DRAW`  … `setCues` した内容が実際に画面へ描かれるまでの時間。
  *  - `SEEK`  … 位置の不連続。シーク直後は復元動作でCueが大きく遅れるのが正常なため。
@@ -103,10 +104,16 @@ class SubtitleStallDiagnostics(private val player: ExoPlayer) {
             val now = SystemClock.uptimeMillis()
             val dt = now - lastBeatUptimeMs
             lastBeatUptimeMs = now
-            if (dt > windowMaxDtMs) windowMaxDtMs = dt
-            // 250ms周期のつもりが大きくずれた=メインスレッドが止まっていた。即時に出す。
-            if (dt >= STALL_THRESHOLD_MS) {
-                Log.w(TAG, "STALL_MAIN_THREAD dt=$dt (メインスレッドが${dt}ms止まった)")
+            // 再生中でないときのビートの遅れは調べたい現象と無関係。再生画面を開いたまま
+            // アプリがバックグラウンドへ回るとプロセスが凍結され、uptimeは進むのにHandlerが
+            // 動かないため、復帰時に何十分ぶんもの「停止」に見えてしまう(実測5041秒)。
+            // 調べたいのは「再生は進んでいるのに字幕だけ止まる」ケースなので、再生中に限る。
+            val playing = player.isPlaying
+            if (playing) {
+                if (dt > windowMaxDtMs) windowMaxDtMs = dt
+                if (dt >= STALL_THRESHOLD_MS) {
+                    Log.w(TAG, "STALL_MAIN_THREAD dt=$dt (メインスレッドが${dt}ms止まった)")
+                }
             }
             if (now - lastSummaryUptimeMs >= SUMMARY_INTERVAL_MS) {
                 lastSummaryUptimeMs = now
@@ -116,7 +123,7 @@ class SubtitleStallDiagnostics(private val player: ExoPlayer) {
                     "BEAT maxDt=$windowMaxDtMs maxDraw=$windowMaxDrawMs cueGap=$cueGap " +
                             "pos=${player.currentPosition} buf=${player.bufferedPosition} " +
                             "totalBuf=${player.totalBufferedDuration} state=${player.playbackState} " +
-                            "playing=${player.isPlaying} " +
+                            "playing=$playing " +
                             "drop=${player.videoDecoderCounters?.droppedBufferCount ?: -1}"
                 )
                 windowMaxDtMs = 0


### PR DESCRIPTION
## 変更内容

字幕詰まりの常設計測で、`STALL_MAIN_THREAD` の計上と警告を**再生中(`player.isPlaying`)に限る**。

再生画面を開いたままアプリがバックグラウンドへ回るとプロセスが凍結され、`uptimeMillis` は進むのに
Handler が動かないため、復帰時に何十分ぶんもの「メインスレッド停止」に見えていた。

実測での誤検知:

- Google TV Streamer: `dt=5041547`(1.4時間)が1件
- Sony BRAVIA: 一時停止中(`playing=false`)に約200秒周期で `dt≈1400〜1550ms` が30分で9件

調べたいのは「再生は進んでいるのに字幕だけ止まる」ケースなので、再生中に限定しても取りこぼしは
生じない。

Refs #69

## なぜ必要か

この警告は「鳴ったら本物」であることに価値がある。誤検知が積み上がるとログの信頼性が失われ、
本物の詰まりを見落とす。実際に上記の9件はすべて字幕と無関係だった。

## テスト項目

- [x] 再生中は `SubStallDiag` の `BEAT` がこれまでどおり出る
- [x] 再生画面を開いたまま数十分放置して戻っても `STALL_MAIN_THREAD` が出ない
- [x] 一時停止したまま放置しても `STALL_MAIN_THREAD` が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
