### PR TITLE
ローダーの動作周期を粗くする (Issue #69 の検証)

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
@@ -362,16 +362,25 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         trackSelector = DefaultTrackSelector(requireContext())
         // TS・ライブは素早い再生開始と低遅延のためバッファを小さく保つ。
         //
-        // 一方、録画済みのエンコード済み動画/HLSでは大きめに取る必要がある。EPGStationが
-        // ffmpegで出力するMP4は字幕トラックの多重化位置が映像から大きくずれることがあり
-        // (sparseなストリームはmax_interleave_deltaの影響で数十秒ぶんずれた位置に書かれる)、
-        // 先読みが小さいと字幕サンプルの到着だけが遅れて「字幕が止まった後に一気に流れて
-        // 追いつく」挙動になる。実測ログでは映像・音声は正常に進みバッファも健全なまま、
-        // 字幕だけ34秒間途切れてから0.5秒で15件まとめて届いていた。
-        // ここはmedia3のDefaultLoadControlの既定値(50秒)に任せる。
+        // エンコード済み動画/HLSは Issue #69 の検証のため、ローダーの動作周期を粗くしている。
+        // 既定は min=max=50秒で、ローダーは50秒に達すると止まり、少し減るとすぐ再開する
+        // ——という小刻みな停止・再開を繰り返す。字幕が数秒〜数十秒止まる現象を計測したところ、
+        // 遅れて届いたCueの到着時刻が、いずれもこの「ローダーが再開してバッファが伸びた瞬間」と
+        // 一致していた(14:32の例では buf=917983 で停滞したまま12.8秒Cueが途切れ、
+        // buf=929461 へ伸びた瞬間に8件がまとめて届いた)。
+        //
+        // そこで min(20秒)と max(60秒)を離し、読み込みの塊を大きくして停止・再開の回数を
+        // 大幅に減らす。詰まりの発生がローダーの停止・再開に追従するなら、この変更で
+        // 発生位置と頻度が目に見えて変わるはず。変わらなければ相関は偶然だったと判定できる。
+        //
+        // 検証が終わったら既定(50秒)へ戻すこと。
         val loadControl = DefaultLoadControl.Builder()
             .apply {
-                if (isTsContent || isAnyLive) setBufferDurationsMs(1_000, 8_000, 500, 1_000)
+                if (isTsContent || isAnyLive) {
+                    setBufferDurationsMs(1_000, 8_000, 500, 1_000)
+                } else {
+                    setBufferDurationsMs(20_000, 60_000, 2_500, 5_000)
+                }
             }
             .build()
 


### PR DESCRIPTION
## 変更内容

エンコード済み動画/HLS のバッファを `min=max=50秒`(media3 既定)から **`min=20秒 / max=60秒`** に変更する。
TS・ライブは従来どおり(1秒/8秒)。

## 何のために

Refs #69

字幕の更新だけが数秒〜数十秒止まる現象について、**遅れて届いた Cue の到着時刻が、いずれも
「ローダーが再開してバッファが伸びた瞬間」と一致している**ことが計測で分かった。

```
14:32:32.527 BEAT pos=857756 buf=917983 totalBuf=60226   ← buf 停滞
14:32:37.527 BEAT pos=867761 buf=917983 totalBuf=50222   ← buf 停滞のまま12.8秒Cueが途切れる
14:32:40.764 CUE  lag=24177 pos=874226 pts=850049 buf=929461  ← buf が伸びた瞬間に8件がまとめて届く
```

既定値は min と max が同値のため、ローダーは50秒に達すると止まり、少し減るとすぐ再開する、という
小刻みな停止・再開を繰り返す。min と max を離すと読み込みが大きな塊になり、停止・再開の回数が
大幅に減る。

- **相関が因果なら**: 詰まりの発生位置と頻度が目に見えて変わる
- **偶然なら**: これまでと同じ頻度・同じ形で発生し続ける

どちらでも切り分けが1つ進む。判定は常設計測の `LATE_CUE` と、`BEAT` の `buf` の動きで行う。

## この変更は暫定であること

**検証が終わったら既定(50秒)へ戻す。** コード上のコメントにも明記した。

なお、この変更は「字幕サンプルの供給が間に合っていない」という仮説に基づくものではない。
再生していたファイルの字幕は**必要先読み最大0.5秒**(実測)で、供給が間に合わない配置ではない。
それにもかかわらず到着がローダーの再開と一致している、という**矛盾**を詰めるための実験である。

## これまでの経緯

| 試行 | 結果 |
|---|---|
| バッファを既定(50秒)へ戻す(#59) | EPGStation の ffmpeg 出力には効いたが、Amatsukaze 出力には効かなかった |
| 字幕を抽出時パースに切り替える(#80) | **効果なし**。切り替え後も再現したため #81 でリバート済み |
| ローダーの動作周期を粗くする(本PR) | 検証中 |

## テスト項目

- [x] エンコード済み動画の再生開始が体感で遅くならない
- [x] シークが従来どおり動く
- [x] 録画オリジナルTS・ライブ視聴が従来どおり(この変更の対象外だが念のため)
- [x] メモリ不足による再生停止が起きない(60秒ぶんのバッファを保持する)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
