### PR TITLE
エンコード済み動画のバッファを既定の50秒へ戻す

### DIFF
--- a/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/PlaybackVideoFragment.kt
@@ -362,25 +362,14 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         trackSelector = DefaultTrackSelector(requireContext())
         // TS・ライブは素早い再生開始と低遅延のためバッファを小さく保つ。
         //
-        // エンコード済み動画/HLSは Issue #69 の検証のため、ローダーの動作周期を粗くしている。
-        // 既定は min=max=50秒で、ローダーは50秒に達すると止まり、少し減るとすぐ再開する
-        // ——という小刻みな停止・再開を繰り返す。字幕が数秒〜数十秒止まる現象を計測したところ、
-        // 遅れて届いたCueの到着時刻が、いずれもこの「ローダーが再開してバッファが伸びた瞬間」と
-        // 一致していた(14:32の例では buf=917983 で停滞したまま12.8秒Cueが途切れ、
-        // buf=929461 へ伸びた瞬間に8件がまとめて届いた)。
+        // エンコード済み動画/HLSは media3 の DefaultLoadControl の既定値(50秒)に任せる。
         //
-        // そこで min(20秒)と max(60秒)を離し、読み込みの塊を大きくして停止・再開の回数を
-        // 大幅に減らす。詰まりの発生がローダーの停止・再開に追従するなら、この変更で
-        // 発生位置と頻度が目に見えて変わるはず。変わらなければ相関は偶然だったと判定できる。
-        //
-        // 検証が終わったら既定(50秒)へ戻すこと。
+        // Issue #69 の検証で一時的に min=20秒/max=60秒へ広げたことがある。「遅れて届いたCueの
+        // 到着がローダーの再開と一致している」という観測が根拠だったが、再生中のバッファ停滞は
+        // 常時50〜77%の時間帯で起きており相関が偽と判明したため、既定へ戻した。
         val loadControl = DefaultLoadControl.Builder()
             .apply {
-                if (isTsContent || isAnyLive) {
-                    setBufferDurationsMs(1_000, 8_000, 500, 1_000)
-                } else {
-                    setBufferDurationsMs(20_000, 60_000, 2_500, 5_000)
-                }
+                if (isTsContent || isAnyLive) setBufferDurationsMs(1_000, 8_000, 500, 1_000)
             }
             .build()
 


### PR DESCRIPTION
## 変更内容

エンコード済み動画/HLS のバッファを `min=20秒 / max=60秒` から **media3 既定の 50 秒**へ戻す。
TS・ライブは従来どおり(1秒/8秒)で変更なし。

この設定は Issue #69 の検証のために PR #83 で一時的に入れたもので、v1.36 として出荷されている。
検証は終わり、**この設定が字幕の詰まりを大幅に悪化させることが実測で確認された**ため戻す。

Refs #69

## 実測

同一端末条件・同一シリーズ・等速再生・media3 1.3.1 で、バッファ設定だけを変えて各4時間。

| | Fire TV | Google TV Streamer |
|---|---|---|
| バッファ | **既定 50 秒** | **min 20 / max 60 秒** |
| 期間 | 4時間1分 | 4時間2分 |
| 話数 / Cue | 9話 / 3,851 | 11話 / 3,962 |
| **字幕の詰まり** | **0 回** | **29 回** |
| `totalBuf` 中央値 | 52.8秒 | 41.5秒(最小 1.2秒) |

再生量はほぼ同じで、0回対29回。**29回中28回がバッファ残量 20.0〜24.7 秒のとき**に発生しており、
下限20秒への到達直後に集中している。遅れは最大 66.6 秒。

同一エピソード・同一台詞でも、バッファが薄いほど遅れが大きい。

| 同一時刻の字幕 | 既定50秒 | min20秒 |
|---|---|---|
| 字幕A | 15.1秒 | 23.5秒 |
| 字幕B | 16.5秒 | 30.4秒 |
| 字幕C | 5.2秒 | 35.2秒 |

## 動作確認

このブランチのビルドで Fire TV を 4時間1分・9話・Cue 3,851件 連続再生し、字幕の詰まり0回・
メインスレッド停止0回・描画遅延0回を確認済み。

## テスト項目

- [x] エンコード済み動画を長時間再生して字幕が詰まらない(4時間・9話で確認)
- [x] 再生開始が体感で遅くならない
- [x] シークが従来どおり動く
- [x] 録画オリジナルTS・ライブ視聴が従来どおり(この変更の対象外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

