### PR TITLE
外部からライブ視聴を開始する deep link を追加

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,27 @@
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- 外部からライブ視聴を開始するための受け口。
+             epcltvapp://live/channelId/<channelId>
+             識別子の種別をパスに含めているのは、将来 remoteControlKeyId のような別の
+             指定方法を足せるようにするため。 -->
+        <activity
+            android:name=".DeepLinkActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.Epcltvapp.DeepLink"
+            android:screenOrientation="landscape">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="epcltvapp" android:host="live" />
+            </intent-filter>
+        </activity>
         <activity android:name=".DetailsActivity"
             android:screenOrientation="landscape"/>
         <activity android:name=".PlaybackActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,6 @@
             android:exported="true"
             android:excludeFromRecents="true"
             android:noHistory="true"
-            android:launchMode="singleTask"
             android:theme="@style/Theme.Epcltvapp.DeepLink"
             android:screenOrientation="landscape">
             <intent-filter>

--- a/app/src/main/java/com/daigorian/epcltvapp/DeepLinkActivity.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/DeepLinkActivity.kt
@@ -84,6 +84,10 @@ class DeepLinkActivity : FragmentActivity() {
 
         startActivity(
             Intent(this, PlaybackActivity::class.java).apply {
+                // 既に再生中なら、その画面を積み上げずに置き換える。
+                // 積むと古い再生が生き続けてストリームを掴んだままになり、チューナーを
+                // 1本ずつ食い潰す。自動化から繰り返し投げられる経路なので実際に起きる。
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 putExtra(DetailsActivity.IS_LIVE_MPEGTS, true)
                 putExtra(DetailsActivity.CHANNEL_ID, channelId)
                 putExtra(DetailsActivity.CHANNEL_NAME, channelName)

--- a/app/src/main/java/com/daigorian/epcltvapp/DeepLinkActivity.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/DeepLinkActivity.kt
@@ -1,0 +1,104 @@
+package com.daigorian.epcltvapp
+
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
+import androidx.fragment.app.FragmentActivity
+import com.daigorian.epcltvapp.epgstationv2caller.EpgStationV2
+
+/**
+ * 外部から投げられた deep link を受けて再生を始めるためだけの、画面を持たない入り口。
+ *
+ *     adb shell am start -a android.intent.action.VIEW -d "epcltvapp://live/channelId/3239123608"
+ *
+ * URI の解釈は [LiveDeepLink]、接続先の初期化は [EpgStationApiInitializer] が持つ。ここは
+ * その2つを繋いで [PlaybackActivity] へ渡すだけにしてある。
+ *
+ * **解釈できない URI や存在しないチャンネルは、黙って既定へ倒さず Toast で知らせる。**
+ * 自動化から投げられる経路なので、誤りが silent に潰れると利用者が気づけないため。
+ */
+class DeepLinkActivity : FragmentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val uri = intent?.data
+        val target = uri?.let { LiveDeepLink.parse(it.scheme, it.host, it.pathSegments) }
+        if (target == null) {
+            Log.d(TAG, "unsupported deep link: $uri")
+            failWith(getString(R.string.deep_link_unsupported))
+            return
+        }
+
+        EpgStationApiInitializer.initialize(this) { result ->
+            when (result) {
+                is EpgStationApiInitializer.Result.V2 -> fetchThenStart(target)
+
+                is EpgStationApiInitializer.Result.V1 ->
+                    failWith(getString(R.string.deep_link_requires_v2))
+
+                is EpgStationApiInitializer.Result.Failed ->
+                    failWith(getString(R.string.connect_epgstation_failed) + "\n" + result.detail)
+            }
+        }
+    }
+
+    /**
+     * 再生に必要なものが揃うのを待つ。
+     *
+     * - ストリーム設定 … 未取得だとプロファイル選択が既定へ落ち、利用者の設定が無視される
+     * - チャンネル一覧 … 表示名の解決と、指定されたチャンネルが実在するかの確認に使う
+     *
+     * Retrofit のコールバックはメインスレッドで呼ばれるため、この件数の数え方で足りる。
+     */
+    private fun fetchThenStart(target: LiveDeepLink.Target) {
+        var remaining = 2
+        val countDown = {
+            remaining -= 1
+            if (remaining == 0) start(target)
+        }
+        EpgStationV2.fetchStreamConfig(countDown)
+        EpgStationV2.fetchChannels(countDown)
+    }
+
+    private fun start(target: LiveDeepLink.Target) {
+        if (isFinishing || isDestroyed) return
+
+        val channelId = when (target) {
+            is LiveDeepLink.Target.ByChannelId -> target.channelId
+        }
+
+        // 一覧そのものが空なら、チャンネルが無いのではなく取得に失敗している
+        if (EpgStationV2.channelMap.isEmpty()) {
+            failWith(getString(R.string.connect_epgstation_failed))
+            return
+        }
+
+        val channelName = EpgStationV2.channelMap[channelId]
+        if (channelName == null) {
+            Log.d(TAG, "channel not found: $channelId")
+            failWith(getString(R.string.deep_link_channel_not_found, channelId.toString()))
+            return
+        }
+
+        startActivity(
+            Intent(this, PlaybackActivity::class.java).apply {
+                putExtra(DetailsActivity.IS_LIVE_MPEGTS, true)
+                putExtra(DetailsActivity.CHANNEL_ID, channelId)
+                putExtra(DetailsActivity.CHANNEL_NAME, channelName)
+            }
+        )
+        finish()
+    }
+
+    private fun failWith(message: String) {
+        if (isFinishing || isDestroyed) return
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+        finish()
+    }
+
+    companion object {
+        private const val TAG = "DeepLinkActivity"
+    }
+}

--- a/app/src/main/java/com/daigorian/epcltvapp/EpgStationApiInitializer.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/EpgStationApiInitializer.kt
@@ -1,0 +1,100 @@
+package com.daigorian.epcltvapp
+
+import android.content.Context
+import android.util.Log
+import androidx.preference.PreferenceManager
+import com.daigorian.epcltvapp.epgstationcaller.EpgStation
+import com.daigorian.epcltvapp.epgstationv2caller.EpgStationV2
+import com.daigorian.epcltvapp.epgstationv2caller.EpgStationV2VersionChecker
+import com.daigorian.epcltvapp.epgstationv2caller.Version
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+/**
+ * Preference に保存された接続先から EPGStation の API クライアントを用意する。
+ *
+ * 元は MainFragment の中にあったが、deep link の受け口（[DeepLinkActivity]）からも同じ
+ * 初期化が要るため切り出した。**画面を持たない**——Toast も画面遷移もここでは行わず、
+ * 結果だけ呼び出し側へ返す。
+ *
+ * チャンネル一覧やストリーム設定の取得はここでは行わない。必要なものは呼び出し側が
+ * 判断して取りに行く（画面によって要るものが違い、待つかどうかも違うため）。
+ */
+object EpgStationApiInitializer {
+
+    private const val TAG = "EpgStationApiInitializer"
+
+    sealed class Result {
+        /** EPGStation v2 として初期化した。 */
+        object V2 : Result()
+
+        /** EPGStation v1 として初期化した。 */
+        object V1 : Result()
+
+        /** 接続できなかった。[detail] は利用者へ見せてよい補足。 */
+        data class Failed(val detail: String) : Result()
+    }
+
+    /**
+     * @param onResult 常に1回だけ呼ばれる。呼ばれた時点で [EpgStation] / [EpgStationV2] の
+     *                 どちらか（または、どちらも失敗なら両方 null）が確定している。
+     */
+    fun initialize(context: Context, onResult: (Result) -> Unit) {
+        EpgStation.api = null
+        EpgStationV2.api = null
+
+        val baseUrl = resolveBaseUrl(context)
+
+        try {
+            EpgStationV2VersionChecker(baseUrl).api.getVersion()
+                .enqueue(object : Callback<Version> {
+                    override fun onResponse(call: Call<Version>, response: Response<Version>) {
+                        if (response.body() != null) {
+                            Log.d(TAG, "detect Version 2.x.x")
+                            EpgStationV2.initAPI(baseUrl)
+                            onResult(Result.V2)
+                        } else {
+                            Log.d(TAG, "detect Version 1.x.x")
+                            EpgStationV2.api = null
+                            EpgStation.initAPI(baseUrl)
+                            onResult(Result.V1)
+                        }
+                    }
+
+                    override fun onFailure(call: Call<Version>, t: Throwable) {
+                        Log.d(TAG, "getVersion API Failure")
+                        onResult(
+                            Result.Failed(context.getString(R.string.please_check_ip_and_port))
+                        )
+                    }
+                })
+        } catch (e: Exception) {
+            onResult(Result.Failed(e.message.orEmpty()))
+        }
+    }
+
+    /** Preference の「カスタムURL」設定に従って base URL を組み立てる。 */
+    private fun resolveBaseUrl(context: Context): String {
+        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val useCustomBaseURL =
+            pref.getBoolean(context.getString(R.string.pref_key_use_custom_base_url), false)
+
+        return if (useCustomBaseURL) {
+            pref.getString(
+                context.getString(R.string.pref_key_custom_base_url),
+                context.getString(R.string.pref_val_custom_base_url_default)
+            )!!
+        } else {
+            val ipAddress = pref.getString(
+                context.getString(R.string.pref_key_ip_addr),
+                context.getString(R.string.pref_val_ip_addr_default)
+            )!!
+            val port = pref.getString(
+                context.getString(R.string.pref_key_port_num),
+                context.getString(R.string.pref_val_port_num_default)
+            )!!
+            "http://$ipAddress:$port/api/"
+        }
+    }
+}

--- a/app/src/main/java/com/daigorian/epcltvapp/LiveDeepLink.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/LiveDeepLink.kt
@@ -1,0 +1,47 @@
+package com.daigorian.epcltvapp
+
+/**
+ * ライブ視聴を外部から開始するための deep link を解釈する。
+ *
+ *     epcltvapp://live/channelId/<channelId>
+ *
+ * 識別子の種別をパスに含めているのは、将来 remoteControlKeyId のような別の指定方法を
+ * 足せるようにするため。種別を増やすときは [Target] にケースを足し、[parse] の when に
+ * 分岐を追加する。
+ *
+ * Android の Uri に依存しない純粋関数として置く。呼び出し側が Uri から scheme / host /
+ * pathSegments を取り出して渡す。
+ */
+object LiveDeepLink {
+
+    const val SCHEME = "epcltvapp"
+
+    private const val HOST_LIVE = "live"
+    private const val TYPE_CHANNEL_ID = "channelId"
+
+    /** 解釈できた指定内容。 */
+    sealed class Target {
+        /** EPGStation のチャンネルID(サービスID)で指定する。 */
+        data class ByChannelId(val channelId: Long) : Target()
+    }
+
+    /**
+     * @return 解釈できた場合は [Target]。この deep link として扱えない場合は null。
+     *         null は「利用者に伝えるべき誤り」であって、黙って既定値へ倒してはならない。
+     */
+    fun parse(scheme: String?, host: String?, pathSegments: List<String>): Target? {
+        if (!SCHEME.equals(scheme, ignoreCase = true)) return null
+        if (!HOST_LIVE.equals(host, ignoreCase = true)) return null
+        if (pathSegments.size != 2) return null
+
+        val type = pathSegments[0]
+        val value = pathSegments[1]
+
+        return when {
+            TYPE_CHANNEL_ID.equals(type, ignoreCase = true) ->
+                value.toLongOrNull()?.let { Target.ByChannelId(it) }
+
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/MainFragment.kt
@@ -200,79 +200,31 @@ class MainFragment : BrowseSupportFragment() {
     }
 
     private fun initEPGStationApi(){
-        //Preferenceに設定されているAPIバージョン、IPアドレス、ポート番号、１回あたりの取得数を読み込んでAPIをセットアップする。
-        EpgStation.api = null //apiをいったん初期化
-        EpgStationV2.api = null //apiをいったん初期化
+        //Preferenceに設定されている接続先でAPIをセットアップする。
+        //接続先の解決とバージョン判定は EpgStationApiInitializer が持つ。deep link の
+        //受け口(DeepLinkActivity)が同じ初期化を必要とするため共通化してある。
+        //一覧の取得はここに残す——画面によって要るものが違うため。
+        EpgStationApiInitializer.initialize(requireContext()) { result ->
+            when (result) {
+                is EpgStationApiInitializer.Result.V2 -> {
+                    EpgStationV2.fetchChannels()
+                    EpgStationV2.fetchStreamConfig()
+                }
 
-        //設定値を取得
-        val pref = PreferenceManager.getDefaultSharedPreferences(context)
-        val useCustomBaseURL = pref.getBoolean(getString(R.string.pref_key_use_custom_base_url),false)
+                is EpgStationApiInitializer.Result.V1 -> {
+                    EpgStation.fetchChannels()
+                }
 
-        //base URL
-        val baseUrl = if (useCustomBaseURL) {
-            //カスタムURL ON の時はそちらを読み込む
-             pref.getString(
-                getString(R.string.pref_key_custom_base_url),
-                getString(R.string.pref_val_custom_base_url_default)
-            )!!
-
-        }else {
-            //カスタムURL OFF の時はIPとPortからURLを生成する
-            val ipAddress = pref.getString(
-                    getString(R.string.pref_key_ip_addr),
-                    getString(R.string.pref_val_ip_addr_default)
-                )!!
-            val port = pref.getString(
-                    getString(R.string.pref_key_port_num),
-                    getString(R.string.pref_val_port_num_default)
-                )!!
-            "http://$ipAddress:$port/api/"
-        }
-
-        //バージョンチェックして適切なバージョンのAPIを初期化
-        try {
-            EpgStationV2VersionChecker(baseUrl).api.getVersion()
-                .enqueue(object : Callback<Version> {
-                    override fun onResponse(call: Call<Version>, response: Response<Version>) {
-                        if (response.body() != null) {
-                            //Version 2で初期化
-                            Log.d(TAG, "initEPGStationApi() detect Version 2.x.x")
-                            EpgStationV2.initAPI(baseUrl)
-                            EpgStationV2.fetchChannels()
-                            EpgStationV2.fetchStreamConfig()
-                            loadRows()
-                        } else {
-                            //Version 1で初期化
-                            Log.d(TAG, "initEPGStationApi() detect Version 1.x.x")
-                            EpgStationV2.api = null
-                            EpgStation.initAPI(baseUrl)
-                            EpgStation.fetchChannels()
-                            loadRows()
-                        }
-                    }
-
-                    override fun onFailure(call: Call<Version>, t: Throwable) {
-                        Log.d(TAG, "initEPGStationApi() getVersion API Failure")
-                        Toast.makeText(
-                            context!!,
-                            getString(R.string.connect_epgstation_failed) + "\n" + getString(R.string.please_check_ip_and_port) ,
-                            Toast.LENGTH_LONG
-                        ).show()
-                        loadRows()
-
-                    }
-                })
-        } catch(e:Exception){
-            Toast.makeText(
-                requireContext(),
-                getString(R.string.connect_epgstation_failed)  + "\n" +  e.message,
-                Toast.LENGTH_LONG
-            ).show()
+                is EpgStationApiInitializer.Result.Failed -> {
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.connect_epgstation_failed) + "\n" + result.detail,
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
             loadRows()
         }
-
-
-
     }
 
     private fun prepareBackgroundManager() {

--- a/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/EpgStationV2.kt
+++ b/app/src/main/java/com/daigorian/epcltvapp/epgstationv2caller/EpgStationV2.kt
@@ -108,23 +108,44 @@ object EpgStationV2 {
     var channelMap: Map<Long, String> = emptyMap()
     var streamConfig: StreamConfig? = null
 
-    fun fetchChannels() {
-        api?.getChannels()?.enqueue(object : Callback<List<ChannelItem>> {
+    /**
+     * @param onComplete 成否によらず必ず1回だけ呼ばれる。api未初期化で送信自体ができない
+     *                   場合も呼ぶ——待っている側を取り残さないため。
+     */
+    fun fetchChannels(onComplete: (() -> Unit)? = null) {
+        val call = api?.getChannels()
+        if (call == null) {
+            onComplete?.invoke()
+            return
+        }
+        call.enqueue(object : Callback<List<ChannelItem>> {
             override fun onResponse(call: Call<List<ChannelItem>>, response: retrofit2.Response<List<ChannelItem>>) {
                 response.body()?.let { list ->
                     channelMap = list.associate { item -> item.id to item.halfWidthName.ifEmpty { item.name } }
                 }
+                onComplete?.invoke()
             }
-            override fun onFailure(call: Call<List<ChannelItem>>, t: Throwable) {}
+            override fun onFailure(call: Call<List<ChannelItem>>, t: Throwable) {
+                onComplete?.invoke()
+            }
         })
     }
 
-    fun fetchStreamConfig() {
-        api?.getConfig()?.enqueue(object : Callback<ConfigResponse> {
+    /** @param onComplete [fetchChannels] と同じ約束。 */
+    fun fetchStreamConfig(onComplete: (() -> Unit)? = null) {
+        val call = api?.getConfig()
+        if (call == null) {
+            onComplete?.invoke()
+            return
+        }
+        call.enqueue(object : Callback<ConfigResponse> {
             override fun onResponse(call: Call<ConfigResponse>, response: retrofit2.Response<ConfigResponse>) {
                 streamConfig = response.body()?.streamConfig
+                onComplete?.invoke()
             }
-            override fun onFailure(call: Call<ConfigResponse>, t: Throwable) {}
+            override fun onFailure(call: Call<ConfigResponse>, t: Throwable) {
+                onComplete?.invoke()
+            }
         })
     }
 

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -136,5 +136,9 @@
     <!-- speed_value_* は言語によらず同じ表記なので values/strings.xml のものをそのまま使う -->
 
     <string name="speed_not_supported">この音声では再生速度を変えられません。1.00x で再生します。</string>
+    <!-- deep link (epcltvapp://live/channelId/<channelId>) -->
+    <string name="deep_link_unsupported">このリンクには対応していません。</string>
+    <string name="deep_link_requires_v2">リンクからのライブ視聴には EPGStation v2 が必要です。</string>
+    <string name="deep_link_channel_not_found">チャンネルが見つかりません: %1$s</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -251,7 +251,9 @@
     <string name="speed_value_150">1.50x</string>
     <string name="speed_value_200">2.00x</string>
     <string name="speed_not_supported">Playback speed cannot be changed for this audio. Playing at 1.00x.</string>
-
-
+    <!-- deep link (epcltvapp://live/channelId/<channelId>) -->
+    <string name="deep_link_unsupported">This link is not supported.</string>
+    <string name="deep_link_requires_v2">Starting live TV from a link requires EPGStation v2.</string>
+    <string name="deep_link_channel_not_found">Channel not found: %1$s</string>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -42,6 +42,13 @@
     <style name="CustomizedSearch" parent="@style/Theme.Epcltvapp">
         <item name="android:windowBackground">@color/background_epgstation</item>
     </style>
-
+    <!-- deep link の受け口用。画面を持たずすぐ次へ遷移するので背景を出さない。
+         Theme.NoDisplay は onResume までに finish() できないと落ちるため使わない
+         (接続先の初期化を待つ間、この画面は生きている必要がある)。 -->
+    <style name="Theme.Epcltvapp.DeepLink" parent="@style/Theme.Epcltvapp">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
 
 </resources>

--- a/app/src/test/java/com/daigorian/epcltvapp/LiveDeepLinkTest.kt
+++ b/app/src/test/java/com/daigorian/epcltvapp/LiveDeepLinkTest.kt
@@ -1,0 +1,85 @@
+package com.daigorian.epcltvapp
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * [LiveDeepLink] のテスト。
+ *
+ * 受け付けるべきものを受け付けることより、**受け付けてはいけないものを弾くこと**を重く見ている。
+ * 解釈できない URI を黙って既定チャンネルへ倒すと、利用者は誤りに気づけないため。
+ */
+class LiveDeepLinkTest {
+
+    private fun parse(uri: String): LiveDeepLink.Target? {
+        // "scheme://host/seg/seg" を Android の Uri に頼らず分解する
+        val schemeEnd = uri.indexOf("://")
+        val scheme = if (schemeEnd >= 0) uri.substring(0, schemeEnd) else null
+        val rest = if (schemeEnd >= 0) uri.substring(schemeEnd + 3) else uri
+        val parts = rest.split("/")
+        val host = parts.firstOrNull()
+        val segments = parts.drop(1).filter { it.isNotEmpty() }
+        return LiveDeepLink.parse(scheme, host, segments)
+    }
+
+    @Test
+    fun channelIdを解釈する() {
+        assertEquals(
+            LiveDeepLink.Target.ByChannelId(3273601024L),
+            parse("epcltvapp://live/channelId/3273601024")
+        )
+    }
+
+    @Test
+    fun 末尾のスラッシュがあっても解釈する() {
+        assertEquals(
+            LiveDeepLink.Target.ByChannelId(1L),
+            parse("epcltvapp://live/channelId/1/")
+        )
+    }
+
+    @Test
+    fun schemeとhostの大小文字は問わない() {
+        assertEquals(
+            LiveDeepLink.Target.ByChannelId(42L),
+            parse("EPCLTVAPP://LIVE/channelId/42")
+        )
+    }
+
+    @Test
+    fun 別のschemeは受け付けない() {
+        assertNull(parse("https://live/channelId/1"))
+    }
+
+    @Test
+    fun 知らないhostは受け付けない() {
+        assertNull(parse("epcltvapp://recorded/channelId/1"))
+    }
+
+    @Test
+    fun 知らない識別子の種別は受け付けない() {
+        // 将来 remoteControlKeyId を足すまでは解釈できない。既定値へ倒さず null を返すこと。
+        assertNull(parse("epcltvapp://live/remoteControlKeyId/1"))
+    }
+
+    @Test
+    fun 種別を省略した形は受け付けない() {
+        assertNull(parse("epcltvapp://live/3273601024"))
+    }
+
+    @Test
+    fun 数値でないchannelIdは受け付けない() {
+        assertNull(parse("epcltvapp://live/channelId/abc"))
+    }
+
+    @Test
+    fun channelIdが空なら受け付けない() {
+        assertNull(parse("epcltvapp://live/channelId/"))
+    }
+
+    @Test
+    fun 余分なパスがあれば受け付けない() {
+        assertNull(parse("epcltvapp://live/channelId/1/extra"))
+    }
+}


### PR DESCRIPTION
Issue #85 の deep link 対応です。ご提案いただいた `epcltvapp://live/channelId/<channelId>` の形を採りました。

```
adb shell am start -a android.intent.action.VIEW -d "epcltvapp://live/channelId/<channelId>"
```

## 構成

- **`LiveDeepLink`** — URI の解釈。Android に依存しない純粋関数にしてテストを添えました。
  識別子の種別をパスに含めているので、将来 `remoteControlKeyId` を足すときは
  `Target` にケースを、`parse` に分岐を足すだけで済みます。
- **`EpgStationApiInitializer`** — 接続先の初期化。`MainFragment` の中にしか無かったため
  切り出しました。画面を持たず、結果だけ返します。
- **`DeepLinkActivity`** — 受け口。上の2つを繋いで `PlaybackActivity` へ渡すだけです。

「コード量より保守性」とのことでしたので、受け口は薄い Activity を新設し、初期化を
共通化する形にしました。`MainFragment` 側は一覧取得・Toast・`loadRows()` を呼び出し側に
残してあるので、**挙動は変わりません**。

再生を始める前にストリーム設定の取得を待ちます。待たないと `streamConfig` が null のまま
プロファイル解決が既定へ落ち、利用者が設定で選んだプロファイルが無視されます。そのため
`fetchChannels` / `fetchStreamConfig` に完了通知の口を足しました(既定 `null` なので既存の
呼び出しは影響を受けません)。

解釈できない URI と存在しないチャンネルは Toast で知らせて終了します。自動化から
投げられる経路なので、黙って既定へ倒すと利用者が誤りに気づけないためです。

## 実機で見つけて直した点

deep link を続けて投げると `PlaybackActivity` が積み上がり、背面に残った再生がストリームを
掴んだままになりました。2分経っても解放されず、チューナーを1本ずつ消費します。チューナーが
2本の環境では3回目の選局で破綻します。ブラウズ画面からの選局では戻ってから選び直すため
表面化しない、deep link 固有の問題でした。`FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TOP`
で置き換えるようにしています。

## 既知の制限

**再生中に解釈できない link を投げると、その再生が一時停止します。**

Android は他の Activity が起動されると、それが表示されるか否かに関わらず前面の Activity へ
`onPause` を送ります。`PlaybackVideoFragment` は `onPause` で再生を止めるため、受け口が
Activity である限り避けられません。回避を2つ試しましたが、いずれも成立しませんでした。

- 受け口を半透明テーマにする → 下の Activity は pause する
- `Theme.NoDisplay` にして同期的に `finish()` する → 同じく pause する
  (`Theme.NoDisplay` と非同期処理の組み合わせは
  `did not call finish() prior to onResume() completing` で落ちます)

`onPause` で止めた分を `onResume` で戻す実装も試しましたが、ホームボタンで離れて戻ったときの
挙動まで変わってしまうため、この PR の範囲を超えると判断して入れていません。

**有効な link の場合は再生を置き換えるので、この制限は表面化しません。**

## 動作確認

Google TV Streamer (Google TV / Android 14) の実機で確認しました。

| 確認項目 | 結果 |
|---|---|
| ユニットテスト | 24件すべて成功(新規10件 + 既存14件) |
| 冷えた状態から有効な link | 指定したチャンネルで再生開始 |
| 再生中に別チャンネルへ切り替え | 切り替わる。`PlaybackActivity` は常に1個、使用チューナーは常に1本 |
| 存在しない channelId | Toast を出して終了。既定チャンネルへ倒れない |
| 解釈できない URI (`.../remoteControlKeyId/1`, `.../channelId/abc`) | 同上 |
| 外部の自動化から | Home Assistant の `media_player.play_media` で URI を投げて選局できることを確認 |

再生中のチャンネルは EPGStation の `/api/streams` で、使用チューナーは mirakc の
`/api/tuners` で、それぞれ外側から突き合わせています。

## 確認できていない点

`remoteControlKeyId` は今回実装していません(URI の形が将来それを受け入れられることの確認まで)。
なお EPGStation の `/api/channels` は `remoteControlKeyId` を返しますが、**複数のサービスが
同じ値を共有する**ため、実装時には同じ番号の中からどれを選ぶかを決める必要がありそうです。
