### PR TITLE
[検証用・マージしない] CI の失敗経路を確認する

### DIFF
--- a/app/src/test/java/com/daigorian/epcltvapp/CiFailureProbeTest.kt
+++ b/app/src/test/java/com/daigorian/epcltvapp/CiFailureProbeTest.kt
@@ -1,0 +1,18 @@
+package com.daigorian.epcltvapp
+
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * **CI の失敗経路を確認するためだけの一時的なテスト。この PR はマージしない。**
+ *
+ * 単体テストが落ちたときに、PR のチェックが赤くなり、テストレポートが artifact として
+ * 保存されるかを確かめる。確認が終わったら PR ごと閉じてブランチを削除する。
+ */
+class CiFailureProbeTest {
+
+    @Test
+    fun わざと失敗してCIが赤くなることを確かめる() {
+        fail("CI の失敗経路を確認するための意図的な失敗です")
+    }
+}


### PR DESCRIPTION
**このPRはマージしません。確認が終わり次第クローズします。**

単体テストが失敗したときに、PR のチェックが赤くなり、テストレポートが artifact として保存されることを確認するための一時的なPRです。意図的に失敗するテストを1件だけ含みます。